### PR TITLE
feat(plugins): add rand.string.pattern() for formatted random strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### 🚀 New Features
+
+- **`module.rand.string.pattern(format_string)`** — build random strings from a printf-like pattern with specifiers `%a %A %l %d %n %h %H %p %w %%` and repeat syntax `{N}` (e.g. `pattern("ORD-%A{3}-%d{6}")`)
+
 ## 2.5.0 (2026-05-14)
 
 ### 🚀 New Features

--- a/eventum/plugins/event/plugins/template/modules/rand.py
+++ b/eventum/plugins/event/plugins/template/modules/rand.py
@@ -16,6 +16,23 @@ from typing import TypeVar, overload
 
 T = TypeVar('T')
 
+_HEX_LOWER = digits + 'abcdef'
+_HEX_UPPER = digits + 'ABCDEF'
+_WORD = ascii_letters + digits
+_NON_ZERO_DIGITS = '123456789'
+
+_PATTERN_CHARSETS: dict[str, str] = {
+    'a': ascii_lowercase,
+    'A': ascii_uppercase,
+    'l': ascii_letters,
+    'd': digits,
+    'n': _NON_ZERO_DIGITS,
+    'h': _HEX_LOWER,
+    'H': _HEX_UPPER,
+    'p': punctuation,
+    'w': _WORD,
+}
+
 
 def shuffle(items: Sequence[T]) -> list[T] | str:
     """Shuffle sequence elements."""
@@ -230,8 +247,80 @@ class string:  # noqa: N801
         """Return string of specified `size` that contains random hex
         characters.
         """
-        hexdigits = digits + 'abcdef'
-        return ''.join(random.choices(hexdigits, k=size))
+        return ''.join(random.choices(_HEX_LOWER, k=size))
+
+    @staticmethod
+    def pattern(format_string: str) -> str:
+        """Return random string built from a printf-like pattern.
+
+        Format specifiers:
+
+        - ``%a`` lowercase letter (a-z)
+        - ``%A`` uppercase letter (A-Z)
+        - ``%l`` any letter (a-zA-Z)
+        - ``%d`` digit (0-9)
+        - ``%n`` non-zero digit (1-9)
+        - ``%h`` lowercase hex (0-9a-f)
+        - ``%H`` uppercase hex (0-9A-F)
+        - ``%p`` ASCII punctuation
+        - ``%w`` word character (a-zA-Z0-9)
+        - ``%%`` literal ``%``
+
+        Append ``{N}`` to a specifier to emit ``N`` random characters
+        from its set instead of one. Other characters in the pattern
+        are emitted as-is.
+
+        Example::
+
+            pattern('%A{3}-%d{4}')  # 'ABC-1234'
+        """
+        result: list[str] = []
+        i = 0
+        n = len(format_string)
+
+        while i < n:
+            c = format_string[i]
+            if c != '%':
+                result.append(c)
+                i += 1
+                continue
+
+            i += 1
+            if i >= n:
+                msg = (
+                    'incomplete format specifier at end of pattern '
+                    "(trailing '%')"
+                )
+                raise ValueError(msg)
+
+            spec = format_string[i]
+            i += 1
+
+            count = 1
+            if i < n and format_string[i] == '{':
+                end = format_string.find('}', i + 1)
+                if end == -1:
+                    msg = "unclosed '{' in pattern"
+                    raise ValueError(msg)
+                count_str = format_string[i + 1 : end]
+                if not count_str.isdigit():
+                    msg = f'invalid repeat count: {count_str!r}'
+                    raise ValueError(msg)
+                count = int(count_str)
+                i = end + 1
+
+            if spec == '%':
+                result.append('%' * count)
+                continue
+
+            charset = _PATTERN_CHARSETS.get(spec)
+            if charset is None:
+                msg = f'unknown format specifier: %{spec}'
+                raise ValueError(msg)
+
+            result.append(''.join(random.choices(charset, k=count)))
+
+        return ''.join(result)
 
 
 class network:  # noqa: N801

--- a/eventum/plugins/event/plugins/template/modules/tests/test_rand.py
+++ b/eventum/plugins/event/plugins/template/modules/tests/test_rand.py
@@ -11,7 +11,7 @@ from string import (
 
 import pytest
 
-import eventum.plugins.event.plugins.template.modules.rand as rand
+from eventum.plugins.event.plugins.template.modules import rand
 
 
 # ---- General Random Functions ----
@@ -156,6 +156,137 @@ def test_string_hex():
     result = rand.string.hex(8)
     assert len(result) == 8
     assert all(c in '0123456789abcdef' for c in result)
+
+
+# ---- String Pattern ----
+def test_string_pattern_empty():
+    assert rand.string.pattern('') == ''
+
+
+def test_string_pattern_literal_only():
+    assert rand.string.pattern('hello') == 'hello'
+
+
+def test_string_pattern_lowercase_letter():
+    result = rand.string.pattern('%a')
+    assert len(result) == 1
+    assert result in ascii_lowercase
+
+
+def test_string_pattern_uppercase_letter():
+    result = rand.string.pattern('%A')
+    assert len(result) == 1
+    assert result in ascii_uppercase
+
+
+def test_string_pattern_any_letter():
+    result = rand.string.pattern('%l{20}')
+    assert len(result) == 20
+    assert all(c in ascii_letters for c in result)
+
+
+def test_string_pattern_digit():
+    result = rand.string.pattern('%d{10}')
+    assert len(result) == 10
+    assert all(c in digits for c in result)
+
+
+def test_string_pattern_non_zero_digit():
+    result = rand.string.pattern('%n{100}')
+    assert len(result) == 100
+    assert all(c in '123456789' for c in result)
+
+
+def test_string_pattern_hex_lower():
+    result = rand.string.pattern('%h{16}')
+    assert len(result) == 16
+    assert all(c in '0123456789abcdef' for c in result)
+
+
+def test_string_pattern_hex_upper():
+    result = rand.string.pattern('%H{16}')
+    assert len(result) == 16
+    assert all(c in '0123456789ABCDEF' for c in result)
+
+
+def test_string_pattern_punctuation():
+    result = rand.string.pattern('%p{10}')
+    assert len(result) == 10
+    assert all(c in punctuation for c in result)
+
+
+def test_string_pattern_word():
+    result = rand.string.pattern('%w{30}')
+    assert len(result) == 30
+    assert all(c in ascii_letters + digits for c in result)
+
+
+def test_string_pattern_escaped_percent():
+    assert rand.string.pattern('%%') == '%'
+
+
+def test_string_pattern_escaped_percent_repeated():
+    assert rand.string.pattern('%%{4}') == '%%%%'
+
+
+def test_string_pattern_mixed():
+    result = rand.string.pattern('ID-%A{2}%d{4}')
+    assert len(result) == 9
+    assert result.startswith('ID-')
+    assert all(c in ascii_uppercase for c in result[3:5])
+    assert all(c in digits for c in result[5:])
+
+
+def test_string_pattern_zero_count():
+    assert rand.string.pattern('a%d{0}b') == 'ab'
+
+
+def test_string_pattern_literal_braces():
+    result = rand.string.pattern('{3}')
+    assert result == '{3}'
+
+
+def test_string_pattern_literal_braces_after_text():
+    result = rand.string.pattern('size={5}')
+    assert result == 'size={5}'
+
+
+def test_string_pattern_no_repeat_emits_one():
+    result = rand.string.pattern('%a%A%d')
+    assert len(result) == 3
+    assert result[0] in ascii_lowercase
+    assert result[1] in ascii_uppercase
+    assert result[2] in digits
+
+
+def test_string_pattern_trailing_percent_raises():
+    with pytest.raises(ValueError, match='trailing'):
+        rand.string.pattern('abc%')
+
+
+def test_string_pattern_unknown_specifier_raises():
+    with pytest.raises(ValueError, match='unknown format specifier'):
+        rand.string.pattern('%z')
+
+
+def test_string_pattern_unclosed_brace_raises():
+    with pytest.raises(ValueError, match='unclosed'):
+        rand.string.pattern('%a{5')
+
+
+def test_string_pattern_non_numeric_count_raises():
+    with pytest.raises(ValueError, match='invalid repeat count'):
+        rand.string.pattern('%a{abc}')
+
+
+def test_string_pattern_negative_count_raises():
+    with pytest.raises(ValueError, match='invalid repeat count'):
+        rand.string.pattern('%a{-3}')
+
+
+def test_string_pattern_empty_count_raises():
+    with pytest.raises(ValueError, match='invalid repeat count'):
+        rand.string.pattern('%a{}')
 
 
 # ---- Network Namespace ----

--- a/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/completions/globals.ts
+++ b/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/completions/globals.ts
@@ -372,6 +372,15 @@ const namespaceCompletions: NamespaceMember = {
                     info: '(size: int) -> str',
                   },
                 },
+                pattern: {
+                  completion: {
+                    label: 'pattern',
+                    type: 'function',
+                    detail:
+                      'Return random string built from a printf-like pattern (%a %A %l %d %n %h %H %p %w %%, repeat with {N})',
+                    info: '(format_string: str) -> str',
+                  },
+                },
               },
             },
 


### PR DESCRIPTION
## Summary

- Adds `module.rand.string.pattern(format_string)` to the template plugin's `rand` module.
- Printf-like syntax: `%a %A %l %d %n %h %H %p %w %%` plus `{N}` repeat (e.g. `pattern("ORD-%A{3}-%d{6}")` -> `"ORD-XYZ-123456"`).
- Includes UI autocomplete (`globals.ts`), docs page entry (`../docs/`), and a `## Unreleased` changelog section.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy eventum/` clean
- [x] `uv run pytest --ignore=tests/integration` - 923 passed (22 new tests for `pattern`)
- [x] `pnpm build` (UI) succeeds
- [x] `pnpm build` (docs) succeeds

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)