### PR TITLE
feat(plugins): add module.rand.network.ip_v6 family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### 🚀 New Features
+
+- **`module.rand.network.ip_v6` family** — generate random IPv6 addresses: `ip_v6()` for the full space, `ip_v6_global()` for global unicast (`2000::/3`), `ip_v6_link_local()` for link-local (`fe80::/10`), `ip_v6_ula()` for unique local (`fc00::/7`)
+
 ## 2.5.0 (2026-05-14)
 
 ### 🚀 New Features

--- a/eventum/plugins/event/plugins/template/modules/rand.py
+++ b/eventum/plugins/event/plugins/template/modules/rand.py
@@ -319,6 +319,32 @@ class network:  # noqa: N801
         return str(net.network_address + offset)
 
     @staticmethod
+    def ip_v6() -> str:
+        """Return random IPv6 address."""
+        return str(ipaddress.IPv6Address(random.getrandbits(128)))
+
+    @staticmethod
+    def ip_v6_global() -> str:
+        """Return random global unicast IPv6 address (2000::/3)."""
+        net = ipaddress.IPv6Network('2000::/3')
+        offset = random.randint(0, net.num_addresses - 1)
+        return str(ipaddress.IPv6Address(int(net.network_address) + offset))
+
+    @staticmethod
+    def ip_v6_link_local() -> str:
+        """Return random link-local IPv6 address (fe80::/10)."""
+        net = ipaddress.IPv6Network('fe80::/10')
+        offset = random.randint(0, net.num_addresses - 1)
+        return str(ipaddress.IPv6Address(int(net.network_address) + offset))
+
+    @staticmethod
+    def ip_v6_ula() -> str:
+        """Return random unique local IPv6 address (fc00::/7)."""
+        net = ipaddress.IPv6Network('fc00::/7')
+        offset = random.randint(0, net.num_addresses - 1)
+        return str(ipaddress.IPv6Address(int(net.network_address) + offset))
+
+    @staticmethod
     def mac() -> str:
         """Return random MAC address."""
         mac = [random.randint(0x00, 0xFF) for _ in range(6)]

--- a/eventum/plugins/event/plugins/template/modules/tests/test_rand.py
+++ b/eventum/plugins/event/plugins/template/modules/tests/test_rand.py
@@ -11,7 +11,7 @@ from string import (
 
 import pytest
 
-import eventum.plugins.event.plugins.template.modules.rand as rand
+from eventum.plugins.event.plugins.template.modules import rand
 
 
 # ---- General Random Functions ----
@@ -212,6 +212,26 @@ def test_ip_v4_in_subnet_invalid_cidr():
 def test_ip_v4_public():
     ip = rand.network.ip_v4_public()
     assert isinstance(ipaddress.ip_address(ip), ipaddress.IPv4Address)
+
+
+def test_ip_v6():
+    ip = rand.network.ip_v6()
+    assert isinstance(ipaddress.ip_address(ip), ipaddress.IPv6Address)
+
+
+def test_ip_v6_global():
+    ip = rand.network.ip_v6_global()
+    assert ipaddress.IPv6Address(ip) in ipaddress.IPv6Network('2000::/3')
+
+
+def test_ip_v6_link_local():
+    ip = rand.network.ip_v6_link_local()
+    assert ipaddress.IPv6Address(ip) in ipaddress.IPv6Network('fe80::/10')
+
+
+def test_ip_v6_ula():
+    ip = rand.network.ip_v6_ula()
+    assert ipaddress.IPv6Address(ip) in ipaddress.IPv6Network('fc00::/7')
 
 
 def test_mac():

--- a/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/completions/globals.ts
+++ b/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/completions/globals.ts
@@ -431,6 +431,41 @@ const namespaceCompletions: NamespaceMember = {
                     info: '(cidr: str) -> str',
                   },
                 },
+                ip_v6: {
+                  completion: {
+                    label: 'ip_v6',
+                    type: 'function',
+                    detail: 'Return random IPv6 address',
+                    info: '() -> str',
+                  },
+                },
+                ip_v6_global: {
+                  completion: {
+                    label: 'ip_v6_global',
+                    type: 'function',
+                    detail:
+                      'Return random global unicast IPv6 address (2000::/3)',
+                    info: '() -> str',
+                  },
+                },
+                ip_v6_link_local: {
+                  completion: {
+                    label: 'ip_v6_link_local',
+                    type: 'function',
+                    detail:
+                      'Return random link-local IPv6 address (fe80::/10)',
+                    info: '() -> str',
+                  },
+                },
+                ip_v6_ula: {
+                  completion: {
+                    label: 'ip_v6_ula',
+                    type: 'function',
+                    detail:
+                      'Return random unique local IPv6 address (fc00::/7)',
+                    info: '() -> str',
+                  },
+                },
                 mac: {
                   completion: {
                     label: 'mac',


### PR DESCRIPTION
## Summary

- Add `ip_v6()`, `ip_v6_global()` (`2000::/3`), `ip_v6_link_local()` (`fe80::/10`), `ip_v6_ula()` (`fc00::/7`) to `module.rand.network`
- Mirror UI autocomplete entries and update CHANGELOG
- Docs page updated separately under `../docs/`

Closes #52

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check` clean
- [x] `uv run mypy eventum/` clean (350 source files)
- [x] `uv run pytest eventum/plugins/event/plugins/template/modules/tests/test_rand.py` — 41/41 passed
- [x] `pnpm build` in `eventum/ui` succeeds
- [x] `pnpm build` in `../docs` succeeds (after docs MDX edit)