### PR TITLE
feat(plugins): add samples.where() and default fallback for picks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### 🚀 New Features
+
+- **`samples.<name>.where(**conditions)`** — filter sample rows by multiple equality conditions in a single call (AND-combined). Replaces verbose chained `selectattr` and returns a `Sample` that supports further `where`/`pick` calls
+- **`pick(default=...)` and `weighted_pick(weight, default=...)`** — return a fallback value when the sample is empty instead of raising; `pick_n` and `weighted_pick_n` return `[]` on empty samples
+
 ## 2.5.0 (2026-05-14)
 
 ### 🚀 New Features

--- a/eventum/plugins/event/plugins/template/sample_reader.py
+++ b/eventum/plugins/event/plugins/template/sample_reader.py
@@ -6,7 +6,7 @@ import random
 from collections.abc import Callable, Iterable
 from io import StringIO
 from pathlib import Path
-from typing import Any, Self
+from typing import Any, Self, TypeVar, overload
 
 import structlog
 import tablib  # type: ignore[import-untyped]
@@ -25,6 +25,10 @@ logger = structlog.stdlib.get_logger()
 
 _EMPTY_FIELD_MAP: dict[str, int] = {}
 
+_MISSING: Any = object()
+
+T = TypeVar('T')
+
 
 class SampleLoadError(ContextualError):
     """Failed to load sample."""
@@ -32,6 +36,10 @@ class SampleLoadError(ContextualError):
 
 class SamplePickError(ContextualError):
     """Failed to pick from sample."""
+
+
+class SampleFilterError(ContextualError):
+    """Failed to filter sample."""
 
 
 class Row(tuple):  # noqa: SLOT001
@@ -78,7 +86,7 @@ class Row(tuple):  # noqa: SLOT001
 
 
 class Sample:
-    """Immutable sample with picking support."""
+    """Immutable sample with picking and filtering support."""
 
     __slots__ = (
         '_cum_weights_cache',
@@ -126,16 +134,142 @@ class Sample:
             return self._rows[key]
         return self._dataset[key]
 
-    def pick(self) -> Row:
-        """Pick a random row (uniform)."""
+    def where(self, **conditions: Any) -> Sample:
+        """Return a sample of rows matching all equality conditions.
+
+        Conditions are kwargs of the form ``column=value`` and are
+        combined with logical AND. The filter is exact-match.
+
+        Parameters
+        ----------
+        **conditions : Any
+            Column-to-value pairs to match.
+
+        Returns
+        -------
+        Sample
+            New sample containing matching rows. May be empty if no
+            row matches all conditions.
+
+        Raises
+        ------
+        SampleFilterError
+            If any condition references a column that is not present
+            in the sample.
+
+        """
+        if not conditions:
+            return self
+
+        unknown = set(conditions) - set(self._field_map)
+        if unknown:
+            msg = 'Unknown column in filter conditions'
+            raise SampleFilterError(
+                msg,
+                context={
+                    'columns': sorted(unknown),
+                    'available_headers': list(self._field_map),
+                },
+            )
+
+        checks = [
+            (self._field_map[col], val) for col, val in conditions.items()
+        ]
+
+        headers = self._dataset.headers
+        if headers:
+            new_data = tablib.Dataset(headers=list(headers))
+        else:
+            new_data = tablib.Dataset()
+
+        for row in self._rows:
+            if all(row[idx] == val for idx, val in checks):
+                new_data.append(tuple(row))
+
+        return Sample(new_data)
+
+    @overload
+    def pick(self) -> Row: ...
+
+    @overload
+    def pick(self, default: T) -> Row | T: ...
+
+    def pick(self, default: Any = _MISSING) -> Any:
+        """Pick a random row (uniform).
+
+        Parameters
+        ----------
+        default : Any, optional
+            Value to return when the sample is empty. If omitted,
+            an empty sample raises :class:`SamplePickError`.
+
+        Returns
+        -------
+        Row | Any
+            Random row, or ``default`` when the sample is empty.
+
+        Raises
+        ------
+        SamplePickError
+            If the sample is empty and no ``default`` is provided.
+
+        """
+        if not self._rows:
+            if default is _MISSING:
+                msg = 'Cannot pick from empty sample'
+                raise SamplePickError(msg, context={})
+            return default
         return random.choice(self._rows)
 
     def pick_n(self, n: int) -> list[Row]:
-        """Pick n random rows (uniform, with replacement)."""
+        """Pick n random rows (uniform, with replacement).
+
+        Returns an empty list when the sample is empty or ``n`` is
+        not positive.
+        """
+        if not self._rows or n <= 0:
+            return []
         return random.choices(self._rows, k=n)
 
-    def weighted_pick(self, weight: str) -> Row:
-        """Pick a random row weighted by the named column."""
+    @overload
+    def weighted_pick(self, weight: str) -> Row: ...
+
+    @overload
+    def weighted_pick(self, weight: str, default: T) -> Row | T: ...
+
+    def weighted_pick(
+        self,
+        weight: str,
+        default: Any = _MISSING,
+    ) -> Any:
+        """Pick a random row weighted by the named column.
+
+        Parameters
+        ----------
+        weight : str
+            Name of the numeric column used for weighting.
+
+        default : Any, optional
+            Value to return when the sample is empty. If omitted,
+            an empty sample raises :class:`SamplePickError`.
+
+        Returns
+        -------
+        Row | Any
+            Random row, or ``default`` when the sample is empty.
+
+        Raises
+        ------
+        SamplePickError
+            If the sample is empty and no ``default`` is provided,
+            or if the weight column is missing or invalid.
+
+        """
+        if not self._rows:
+            if default is _MISSING:
+                msg = 'Cannot pick from empty sample'
+                raise SamplePickError(msg, context={})
+            return default
         cum_weights = self._get_cum_weights(weight)
         return random.choices(
             self._rows,
@@ -148,7 +282,13 @@ class Sample:
         weight: str,
         n: int,
     ) -> list[Row]:
-        """Pick n random rows weighted by the named column."""
+        """Pick n random rows weighted by the named column.
+
+        Returns an empty list when the sample is empty or ``n`` is
+        not positive.
+        """
+        if not self._rows or n <= 0:
+            return []
         cum_weights = self._get_cum_weights(weight)
         return random.choices(
             self._rows,

--- a/eventum/plugins/event/plugins/template/tests/test_sample_reader.py
+++ b/eventum/plugins/event/plugins/template/tests/test_sample_reader.py
@@ -12,6 +12,7 @@ from eventum.plugins.event.plugins.template.config import (
 from eventum.plugins.event.plugins.template.sample_reader import (
     Row,
     Sample,
+    SampleFilterError,
     SampleLoadError,
     SamplePickError,
     SamplesReader,
@@ -574,3 +575,161 @@ def test_weighted_pick_caches_weights(weighted_csv_sample_config):
 
     # Second call uses cache
     sample.weighted_pick('weight')
+
+
+# --- Filtering and empty-sample tests ---
+
+
+def test_where_single_condition(csv_sample_config):
+    sample_reader = SamplesReader(csv_sample_config, BASE_PATH)
+    sample = sample_reader['csv_sample']
+
+    filtered = sample.where(position='Manager')
+    assert isinstance(filtered, Sample)
+    assert len(filtered) == 1
+    assert filtered[0].name == 'John'
+
+
+def test_where_multiple_conditions_anded(csv_sample_config):
+    sample_reader = SamplesReader(csv_sample_config, BASE_PATH)
+    sample = sample_reader['csv_sample']
+
+    filtered = sample.where(name='Jane', position='HR')
+    assert len(filtered) == 1
+    assert filtered[0].name == 'Jane'
+
+    # AND - no row matches both
+    filtered = sample.where(name='Jane', position='Manager')
+    assert len(filtered) == 0
+
+
+def test_where_empty_result_is_valid_sample(csv_sample_config):
+    sample_reader = SamplesReader(csv_sample_config, BASE_PATH)
+    sample = sample_reader['csv_sample']
+
+    filtered = sample.where(position='nonexistent')
+    assert isinstance(filtered, Sample)
+    assert len(filtered) == 0
+
+
+def test_where_unknown_column_raises(csv_sample_config):
+    sample_reader = SamplesReader(csv_sample_config, BASE_PATH)
+    sample = sample_reader['csv_sample']
+
+    with pytest.raises(SampleFilterError, match='Unknown column'):
+        sample.where(nonexistent='foo')
+
+
+def test_where_no_conditions_returns_self(csv_sample_config):
+    sample_reader = SamplesReader(csv_sample_config, BASE_PATH)
+    sample = sample_reader['csv_sample']
+
+    assert sample.where() is sample
+
+
+def test_where_chainable(csv_sample_config):
+    sample_reader = SamplesReader(csv_sample_config, BASE_PATH)
+    sample = sample_reader['csv_sample']
+
+    filtered = sample.where(name='Jane').where(position='HR')
+    assert len(filtered) == 1
+    assert filtered[0].name == 'Jane'
+
+
+def test_where_then_pick(csv_sample_config):
+    sample_reader = SamplesReader(csv_sample_config, BASE_PATH)
+    sample = sample_reader['csv_sample']
+
+    row = sample.where(position='Manager').pick()
+    assert row.name == 'John'
+
+
+def test_where_then_weighted_pick(weighted_csv_sample_config):
+    sample_reader = SamplesReader(weighted_csv_sample_config, BASE_PATH)
+    sample = sample_reader['weighted_csv']
+
+    row = sample.where(name='Jane').weighted_pick('weight')
+    assert row.name == 'Jane'
+
+
+def test_pick_default_on_empty(csv_sample_config):
+    sample_reader = SamplesReader(csv_sample_config, BASE_PATH)
+    sample = sample_reader['csv_sample']
+
+    empty = sample.where(position='nonexistent')
+    assert empty.pick(default=None) is None
+    assert empty.pick(default='fallback') == 'fallback'
+
+
+def test_pick_no_default_on_empty_raises(csv_sample_config):
+    sample_reader = SamplesReader(csv_sample_config, BASE_PATH)
+    sample = sample_reader['csv_sample']
+
+    empty = sample.where(position='nonexistent')
+    with pytest.raises(SamplePickError, match='empty sample'):
+        empty.pick()
+
+
+def test_pick_n_on_empty_returns_empty_list(csv_sample_config):
+    sample_reader = SamplesReader(csv_sample_config, BASE_PATH)
+    sample = sample_reader['csv_sample']
+
+    empty = sample.where(position='nonexistent')
+    assert empty.pick_n(5) == []
+
+
+def test_pick_n_with_zero(csv_sample_config):
+    sample_reader = SamplesReader(csv_sample_config, BASE_PATH)
+    sample = sample_reader['csv_sample']
+
+    assert sample.pick_n(0) == []
+
+
+def test_weighted_pick_default_on_empty(weighted_csv_sample_config):
+    sample_reader = SamplesReader(weighted_csv_sample_config, BASE_PATH)
+    sample = sample_reader['weighted_csv']
+
+    empty = sample.where(name='nonexistent')
+    assert empty.weighted_pick('weight', default=None) is None
+
+
+def test_weighted_pick_no_default_on_empty_raises(
+    weighted_csv_sample_config,
+):
+    sample_reader = SamplesReader(weighted_csv_sample_config, BASE_PATH)
+    sample = sample_reader['weighted_csv']
+
+    empty = sample.where(name='nonexistent')
+    with pytest.raises(SamplePickError, match='empty sample'):
+        empty.weighted_pick('weight')
+
+
+def test_weighted_pick_n_on_empty_returns_empty_list(
+    weighted_csv_sample_config,
+):
+    sample_reader = SamplesReader(weighted_csv_sample_config, BASE_PATH)
+    sample = sample_reader['weighted_csv']
+
+    empty = sample.where(name='nonexistent')
+    assert empty.weighted_pick_n('weight', 5) == []
+
+
+def test_where_preserves_named_access(csv_sample_config):
+    sample_reader = SamplesReader(csv_sample_config, BASE_PATH)
+    sample = sample_reader['csv_sample']
+
+    filtered = sample.where(position='Manager')
+    row = filtered[0]
+    assert row.name == 'John'
+    assert row.email == 'john@example.com'
+
+
+def test_where_on_items_sample_uses_numeric_columns(
+    items_sample_config,
+):
+    sample_reader = SamplesReader(items_sample_config, BASE_PATH)
+    sample = sample_reader['items_sample']
+
+    filtered = sample.where(_0='one')
+    assert len(filtered) == 1
+    assert filtered[0] == ('one', 'two')


### PR DESCRIPTION
## Summary

- `samples.<name>.where(**conditions)` filters rows by multiple equality conditions in a single call (AND-combined), replacing verbose chained `selectattr` and returning a `Sample` that supports further `where`/`pick` calls
- `pick(default=...)` and `weighted_pick(weight, default=...)` accept a fallback for empty samples instead of raising; `pick_n` and `weighted_pick_n` return `[]` on empty samples
- New `SampleFilterError` carries the unknown column name and available headers in its context

Closes #65

## Test plan

- [x] Unit tests for `where`: single/multiple conditions, AND semantics, empty result, unknown column, chainability, integration with `pick`/`weighted_pick`, items-sample numeric columns
- [x] Unit tests for empty-sample behavior on `pick`/`weighted_pick` with and without `default`, and on `pick_n`/`weighted_pick_n`
- [x] `uv run ruff check .` passes
- [x] `uv run mypy eventum/` passes (350 source files)
- [x] Full `pytest --ignore=tests/integration` runs (53/53 for sample_reader; two `test_manage.py` failures are pre-existing test-pollution flakes unrelated to this change)
- [ ] User-facing docs updated on `docs/develop` (separate repo): `samples.mdx` adds a `## Filtering rows` section and a `default` note on the picking tables; `examples.mdx` "Filtering sample data" now leads with `where()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)