### PR TITLE
feat(plugins): add module.rand.network.ip_v4_private() (any class)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - **`samples.<name>.where(**conditions)`** — filter sample rows by multiple equality conditions in a single call (AND-combined). Replaces verbose chained `selectattr` and returns a `Sample` that supports further `where`/`pick` calls
 - **`pick(default=...)` and `weighted_pick(weight, default=...)`** — return a fallback value when the sample is empty instead of raising; `pick_n` and `weighted_pick_n` return `[]` on empty samples
 - **`module.rand.network.ip_v6` family** — generate random IPv6 addresses: `ip_v6()` for the full space, `ip_v6_global()` for global unicast (`2000::/3`), `ip_v6_link_local()` for link-local (`fe80::/10`), `ip_v6_ula()` for unique local (`fc00::/7`)
+- **`module.rand.network.ip_v4_private()`** — generate a random RFC 1918 private IPv4 address from any class (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) with realistic weights
 - **`module.rand.string.pattern(format_string)`** — build random strings from a printf-like pattern with specifiers `%a %A %l %d %n %h %H %p %w %%` and repeat syntax `{N}` (e.g. `pattern("ORD-%A{3}-%d{6}")`)
 
 ## 2.5.0 (2026-05-14)

--- a/eventum/plugins/event/plugins/template/modules/rand.py
+++ b/eventum/plugins/event/plugins/template/modules/rand.py
@@ -366,6 +366,25 @@ class network:  # noqa: N801
         return '.'.join(str(random.randint(0, 255)) for _ in range(4))
 
     @staticmethod
+    def ip_v4_private() -> str:
+        """Return random private IPv4 address (RFC 1918, any class)."""
+        private_ranges = [
+            ('10.0.0.0', '10.255.255.255'),
+            ('172.16.0.0', '172.31.255.255'),
+            ('192.168.0.0', '192.168.255.255'),
+        ]
+        start, end = random.choices(
+            population=private_ranges,
+            weights=[5, 2, 5],
+            k=1,
+        ).pop()
+        ipv4_int = random.randint(
+            int(ipaddress.IPv4Address(start)),
+            int(ipaddress.IPv4Address(end)),
+        )
+        return str(ipaddress.IPv4Address(ipv4_int))
+
+    @staticmethod
     def ip_v4_private_a() -> str:
         """Return random private IPv4 address of Class A."""
         ipv4_int = random.randint(

--- a/eventum/plugins/event/plugins/template/modules/tests/test_rand.py
+++ b/eventum/plugins/event/plugins/template/modules/tests/test_rand.py
@@ -295,6 +295,27 @@ def test_ip_v4():
     assert isinstance(ipaddress.ip_address(ip), ipaddress.IPv4Address)
 
 
+def test_ip_v4_private():
+    private_nets = [
+        ipaddress.IPv4Network('10.0.0.0/8'),
+        ipaddress.IPv4Network('172.16.0.0/12'),
+        ipaddress.IPv4Network('192.168.0.0/16'),
+    ]
+    seen_nets: set[int] = set()
+    for _ in range(200):
+        ip = rand.network.ip_v4_private()
+        addr = ipaddress.IPv4Address(ip)
+        matched = next(
+            (i for i, net in enumerate(private_nets) if addr in net),
+            None,
+        )
+        assert matched is not None, f'{ip} not in any RFC 1918 range'
+        seen_nets.add(matched)
+    assert seen_nets == {0, 1, 2}, (
+        f'expected all three ranges to be sampled, got {seen_nets}'
+    )
+
+
 def test_ip_v4_private_a():
     ip = rand.network.ip_v4_private_a()
     assert ip.startswith('10.')

--- a/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/completions/globals.ts
+++ b/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/completions/globals.ts
@@ -399,6 +399,15 @@ const namespaceCompletions: NamespaceMember = {
                     info: '() -> str',
                   },
                 },
+                ip_v4_private: {
+                  completion: {
+                    label: 'ip_v4_private',
+                    type: 'function',
+                    detail:
+                      'Return random private IPv4 address (RFC 1918, any class)',
+                    info: '() -> str',
+                  },
+                },
                 ip_v4_private_a: {
                   completion: {
                     label: 'ip_v4_private_a',


### PR DESCRIPTION
## Summary

- Add `module.rand.network.ip_v4_private()` returning a random RFC 1918 IPv4 from any class (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`)
- Weights `[5, 2, 5]` reflect approximate real-world prevalence (A and C common in datacenters/home, B less common)
- Mirror UI autocomplete in `globals.ts` and add a CHANGELOG entry
- Docs page already updated on `origin/develop` (commit `03e5d2a`, bundled with sha1 docs commit)

Closes #55

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check` clean
- [x] `uv run mypy eventum/` clean (350 source files)
- [x] `uv run pytest --ignore=tests/integration` - 945/945 passed
- [x] `pnpm build` in `eventum/ui` succeeds
- [x] `pnpm build` in `../docs` succeeds