### PR TITLE
feat(plugins): add OUI prefix support to module.rand.network.mac()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - **`samples.<name>.where(**conditions)`** — filter sample rows by multiple equality conditions in a single call (AND-combined). Replaces verbose chained `selectattr` and returns a `Sample` that supports further `where`/`pick` calls
 - **`pick(default=...)` and `weighted_pick(weight, default=...)`** — return a fallback value when the sample is empty instead of raising; `pick_n` and `weighted_pick_n` return `[]` on empty samples
 - **`module.rand.network.ip_v6` family** — generate random IPv6 addresses: `ip_v6()` for the full space, `ip_v6_global()` for global unicast (`2000::/3`), `ip_v6_link_local()` for link-local (`fe80::/10`), `ip_v6_ula()` for unique local (`fc00::/7`)
+- **`module.rand.network.mac(oui=..., vendor=...)`** — fix the OUI prefix to a 3-byte string (e.g. `mac(oui="00:50:56")`) or pick one at random from a built-in table for a given vendor (e.g. `mac(vendor="dell")`); 20 vendor keys cover Apple, Cisco, Dell, HP, Intel, VMware, and others. No-argument call keeps the previous fully-random behavior
 - **`module.rand.string.pattern(format_string)`** — build random strings from a printf-like pattern with specifiers `%a %A %l %d %n %h %H %p %w %%` and repeat syntax `{N}` (e.g. `pattern("ORD-%A{3}-%d{6}")`)
 
 ## 2.5.0 (2026-05-14)

--- a/eventum/plugins/event/plugins/template/modules/rand.py
+++ b/eventum/plugins/event/plugins/template/modules/rand.py
@@ -34,6 +34,53 @@ _PATTERN_CHARSETS: dict[str, str] = {
     'w': _WORD,
 }
 
+# OUI prefixes per vendor. Each value is a tuple of 3-byte prefixes
+# expressed in lowercase colon notation. Source: public IEEE OUI
+# assignments, sampled to give a few prefixes per vendor.
+_VENDOR_OUIS: dict[str, tuple[str, ...]] = {
+    'apple': ('00:03:93', '00:1f:f3', '04:0c:ce', '6c:96:cf', 'f0:b4:79'),
+    'aruba': ('00:0b:86', '00:1a:1e', '20:4c:03', '94:b4:0f'),
+    'broadcom': ('00:0a:f7', '00:10:18', '00:1b:e9', 'd4:01:29'),
+    'cisco': ('00:00:0c', '00:01:42', '00:1b:54', '00:24:97', 'a4:6c:2a'),
+    'dell': ('00:14:22', '18:03:73', '34:17:eb', 'b0:83:fe', 'f8:db:88'),
+    'fortinet': ('00:09:0f', '04:d5:90', '90:6c:ac', 'e0:23:ff'),
+    'hp': ('00:01:e6', '00:08:83', '00:0e:7f', '3c:d9:2b', '94:18:82'),
+    'huawei': ('00:18:82', '00:1e:10', '04:25:c5', '20:f3:a3', '38:bc:01'),
+    'ibm': ('00:01:e1', '00:09:6b', '00:14:5e', '00:17:ef', '00:21:5e'),
+    'intel': ('00:03:47', '00:07:e9', '00:13:02', 'a0:36:9f', 'e8:b1:fc'),
+    'juniper': ('00:05:85', '00:12:1e', '00:14:f6', '00:17:cb', '00:1f:12'),
+    'lenovo': ('00:21:cc', '54:e1:ad', 'a0:51:0b', 'cc:07:e4', 'e8:6f:38'),
+    'microsoft': ('00:03:ff', '00:15:5d', '00:50:f2', '28:18:78', '60:45:bd'),
+    'mikrotik': ('00:0c:42', '4c:5e:0c', '6c:3b:6b', 'b8:69:f4'),
+    'netgear': ('00:09:5b', '00:14:6c', '00:1b:2f', '20:e5:2a', '4c:60:de'),
+    'paloalto': ('00:1b:17', 'b4:0c:25'),
+    'samsung': ('00:07:ab', '00:23:39', '08:08:c2', '34:23:ba', 'f0:08:f1'),
+    'tplink': ('00:1d:0f', '14:cc:20', '50:c7:bf', '98:da:c4', 'd8:0d:17'),
+    'ubiquiti': ('00:15:6d', '04:18:d6', '24:5a:4c', '74:ac:b9', 'fc:ec:da'),
+    'vmware': ('00:05:69', '00:0c:29', '00:1c:14', '00:50:56'),
+}
+
+
+@functools.lru_cache(maxsize=256)
+def _parse_oui(oui: str) -> tuple[int, int, int]:
+    """Parse a 3-byte OUI prefix into a tuple of integers.
+
+    Accepts ``aa:bb:cc`` and ``aa-bb-cc`` (case-insensitive). Each
+    octet must be exactly two hex digits. Raises ``ValueError`` for
+    any other shape. Cached because callers may invoke ``mac()`` on
+    the hot path with the same prefix repeatedly.
+    """
+    parts = oui.replace('-', ':').split(':')
+    if len(parts) != 3 or not all(len(p) == 2 for p in parts):  # noqa: PLR2004
+        msg = f'invalid OUI prefix: {oui!r}'
+        raise ValueError(msg)
+    try:
+        a, b, c = (int(p, 16) for p in parts)
+    except ValueError:
+        msg = f'invalid OUI prefix: {oui!r}'
+        raise ValueError(msg) from None
+    return a, b, c
+
 
 def _parse_brace_count(format_string: str, start: int) -> tuple[int, int]:
     """Parse a ``{N}`` block at `start` (the ``{`` position).
@@ -468,11 +515,42 @@ class network:  # noqa: N801
         return str(ipaddress.IPv6Address(int(net.network_address) + offset))
 
     @staticmethod
-    def mac() -> str:
-        """Return random MAC address."""
-        mac = [random.randint(0x00, 0xFF) for _ in range(6)]
+    def mac(
+        *,
+        oui: str | None = None,
+        vendor: str | None = None,
+    ) -> str:
+        """Return random MAC address.
 
-        return ':'.join(f'{x:02x}' for x in mac)
+        Without arguments, all six bytes are random. With `oui`, the
+        given 3-byte prefix is reused and only the last three bytes
+        vary; `oui` accepts ``aa:bb:cc`` or ``aa-bb-cc``. With
+        `vendor`, the prefix is picked at random from a built-in OUI
+        table for that vendor (case-insensitive lookup). Pass at
+        most one of `oui` or `vendor`.
+
+        Raises ``ValueError`` for an invalid `oui`, an unknown
+        `vendor`, or both arguments at once.
+        """
+        if oui is not None and vendor is not None:
+            msg = "'oui' and 'vendor' are mutually exclusive"
+            raise ValueError(msg)
+
+        if vendor is not None:
+            ouis = _VENDOR_OUIS.get(vendor.lower())
+            if ouis is None:
+                msg = f'unknown vendor: {vendor!r}'
+                raise ValueError(msg)
+            oui = random.choice(ouis)
+
+        if oui is not None:
+            prefix = _parse_oui(oui)
+            suffix = (random.randint(0, 0xFF) for _ in range(3))
+            octets = (*prefix, *suffix)
+        else:
+            octets = tuple(random.randint(0, 0xFF) for _ in range(6))
+
+        return ':'.join(f'{x:02x}' for x in octets)
 
 
 class crypto:  # noqa: N801

--- a/eventum/plugins/event/plugins/template/modules/tests/test_rand.py
+++ b/eventum/plugins/event/plugins/template/modules/tests/test_rand.py
@@ -371,6 +371,53 @@ def test_mac():
     assert all(0 <= int(x, 16) <= 255 for x in mac.split(':'))
 
 
+def test_mac_with_oui():
+    mac = rand.network.mac(oui='00:50:56')
+    parts = mac.split(':')
+    assert len(parts) == 6
+    assert parts[:3] == ['00', '50', '56']
+    assert all(0 <= int(x, 16) <= 255 for x in parts[3:])
+
+
+def test_mac_oui_accepts_dashes():
+    mac = rand.network.mac(oui='aa-bb-cc')
+    assert mac.startswith('aa:bb:cc:')
+
+
+def test_mac_oui_invalid():
+    for bad in ('', '00:50', '00:50:56:78', 'gg:50:56', '0:50:56', 'xyz'):
+        with pytest.raises(ValueError, match='invalid OUI prefix'):
+            rand.network.mac(oui=bad)
+
+
+def test_mac_with_vendor():
+    mac = rand.network.mac(vendor='dell')
+    prefix = ':'.join(mac.split(':')[:3])
+    assert prefix in {
+        '00:14:22',
+        '18:03:73',
+        '34:17:eb',
+        'b0:83:fe',
+        'f8:db:88',
+    }
+
+
+def test_mac_vendor_case_insensitive():
+    mac = rand.network.mac(vendor='VMware')
+    prefix = ':'.join(mac.split(':')[:3])
+    assert prefix in {'00:05:69', '00:0c:29', '00:1c:14', '00:50:56'}
+
+
+def test_mac_unknown_vendor():
+    with pytest.raises(ValueError, match='unknown vendor'):
+        rand.network.mac(vendor='nosuchvendor')
+
+
+def test_mac_oui_and_vendor_mutually_exclusive():
+    with pytest.raises(ValueError, match='mutually exclusive'):
+        rand.network.mac(oui='00:50:56', vendor='vmware')
+
+
 # ---- Crypto Namespace ----
 def test_uuid4():
     assert isinstance(uuid.UUID(rand.crypto.uuid4()), uuid.UUID)

--- a/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/completions/globals.ts
+++ b/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/completions/globals.ts
@@ -479,8 +479,9 @@ const namespaceCompletions: NamespaceMember = {
                   completion: {
                     label: 'mac',
                     type: 'function',
-                    detail: 'Return random MAC address',
-                    info: '() -> str',
+                    detail:
+                      'Return random MAC address, optionally with a fixed OUI prefix or vendor-picked OUI',
+                    info: '(*, oui: str | None = None, vendor: str | None = None) -> str',
                   },
                 },
               },


### PR DESCRIPTION
## Summary

Extends `module.rand.network.mac()` with two mutually-exclusive keyword arguments:

- `oui="aa:bb:cc"` (or `aa-bb-cc`) — keep this 3-byte prefix, randomise the last three bytes.
- `vendor="dell"` — pick an OUI at random from a built-in table for the given vendor (case-insensitive lookup).

Vendor table covers 20 common vendors: `apple`, `aruba`, `broadcom`, `cisco`, `dell`, `fortinet`, `hp`, `huawei`, `ibm`, `intel`, `juniper`, `lenovo`, `microsoft`, `mikrotik`, `netgear`, `paloalto`, `samsung`, `tplink`, `ubiquiti`, `vmware`.

No-argument call (`mac()`) keeps the previous fully-random behavior. OUI parsing is wrapped in `lru_cache` so per-event template calls do not re-parse the same prefix.

UI autocomplete (`globals.ts`) and `CHANGELOG.md` updated. Docs page updated separately on `eventum-generator/docs` `develop`.

Closes #61

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy eventum/`
- [x] `uv run pytest --ignore=tests/integration` (951 passed)
- [x] `cd eventum/ui && pnpm build`
- [x] `cd ../docs && pnpm build`
- [x] 7 new tests in `test_rand.py` cover backwards compatibility, valid/invalid OUI, dash-separated OUI, valid vendor, case-insensitive vendor lookup, unknown vendor, and the mutually-exclusive guard.