### PR TITLE
fix(plugins): size ClickHouse HTTP pool to match concurrent writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - **`pick(default=...)` and `weighted_pick(weight, default=...)`** — return a fallback value when the sample is empty instead of raising; `pick_n` and `weighted_pick_n` return `[]` on empty samples
 - **`module.rand.network.ip_v6` family** — generate random IPv6 addresses: `ip_v6()` for the full space, `ip_v6_global()` for global unicast (`2000::/3`), `ip_v6_link_local()` for link-local (`fe80::/10`), `ip_v6_ula()` for unique local (`fc00::/7`)
 - **`module.rand.string.pattern(format_string)`** — build random strings from a printf-like pattern with specifiers `%a %A %l %d %n %h %H %p %w %%` and repeat syntax `{N}` (e.g. `pattern("ORD-%A{3}-%d{6}")`)
+- **ClickHouse output: `pool_maxsize` parameter** — configure the HTTP connection pool size toward the ClickHouse host (default `32`); raise it together with `generation.max_concurrency` to avoid `Connection pool is full` warnings and connection churn under bursts of concurrent writes
 
 ## 2.5.0 (2026-05-14)
 

--- a/eventum/plugins/output/plugins/clickhouse/config.py
+++ b/eventum/plugins/output/plugins/clickhouse/config.py
@@ -83,6 +83,12 @@ class ClickhouseOutputPluginConfig(OutputPluginConfig, frozen=True):
     proxy_url : HttpUrl | None, default=None
         HTTP(S) proxy address.
 
+    pool_maxsize : int, default=32
+        Maximum number of HTTP connections kept in the underlying
+        connection pool toward the ClickHouse host. Raise this value
+        together with `generation.max_concurrency` to avoid the pool
+        discarding connections under bursts of concurrent writes.
+
     input_format : ClickhouseInputFormat, default='JSONEachRow'
         ClickHouse input format for inserting, documentation:
         https://clickhouse.com/docs/en/interfaces/formats
@@ -123,6 +129,7 @@ class ClickhouseOutputPluginConfig(OutputPluginConfig, frozen=True):
     server_host_name: str | None = Field(default=None, min_length=1)
     tls_mode: Literal['proxy', 'strict', 'mutual'] | None = Field(default=None)
     proxy_url: HttpUrl | None = Field(default=None)
+    pool_maxsize: int = Field(default=32, ge=1)
     input_format: ClickhouseInputFormat = Field(
         default='JSONEachRow',
         validate_default=True,

--- a/eventum/plugins/output/plugins/clickhouse/plugin.py
+++ b/eventum/plugins/output/plugins/clickhouse/plugin.py
@@ -1,10 +1,11 @@
 """Definition of clickhouse output plugin."""
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING, Any, override
 
 from clickhouse_connect import get_async_client
 from clickhouse_connect.driver.binding import quote_identifier as quote
+from clickhouse_connect.driver.httputil import get_pool_manager
 
 from eventum.plugins.output.base.plugin import OutputPlugin, OutputPluginParams
 from eventum.plugins.output.exceptions import PluginOpenError, PluginWriteError
@@ -14,6 +15,7 @@ from eventum.plugins.output.plugins.clickhouse.config import (
 
 if TYPE_CHECKING:
     from clickhouse_connect.driver.asyncclient import AsyncClient
+    from urllib3.poolmanager import PoolManager
 
 
 class ClickhouseOutputPlugin(
@@ -33,10 +35,51 @@ class ClickhouseOutputPlugin(
             [quote(config.database), quote(config.table)],
         )
         self._client: AsyncClient
+        self._pool_mgr: PoolManager
+
+    def _create_pool_manager(self) -> PoolManager:
+        """Create urllib3 pool manager sized for concurrent writes.
+
+        Notes
+        -----
+        `clickhouse_connect.get_async_client` builds its own pool
+        manager with `maxsize=8` by default, which becomes a bottleneck
+        under Eventum's concurrent output writes. When a custom
+        `pool_mgr` is passed, TLS and proxy options must be configured
+        on the pool itself - the client skips applying them otherwise.
+
+        """
+        options: dict[str, Any] = {
+            'maxsize': self._config.pool_maxsize,
+            'verify': self._config.verify,
+        }
+        if self._config.ca_cert is not None:
+            options['ca_cert'] = str(self.resolve_path(self._config.ca_cert))
+        if self._config.client_cert is not None:
+            options['client_cert'] = str(
+                self.resolve_path(self._config.client_cert),
+            )
+        if self._config.client_cert_key is not None:
+            options['client_cert_key'] = str(
+                self.resolve_path(self._config.client_cert_key),
+            )
+        if self._config.server_host_name is not None:
+            if self._config.verify:
+                options['assert_hostname'] = self._config.server_host_name
+            options['server_hostname'] = self._config.server_host_name
+        if self._config.proxy_url is not None:
+            proxy_url = str(self._config.proxy_url)
+            if self._config.protocol == 'https':
+                options['https_proxy'] = proxy_url
+            else:
+                options['http_proxy'] = proxy_url
+
+        return get_pool_manager(**options)
 
     @override
     async def _open(self) -> None:
         try:
+            self._pool_mgr = self._create_pool_manager()
             self._client = await get_async_client(
                 host=self._config.host,
                 port=self._config.port,
@@ -49,11 +92,6 @@ class ClickhouseOutputPlugin(
                 send_receive_timeout=self._config.request_timeout,
                 client_name=self._config.client_name,
                 verify=self._config.verify,
-                ca_cert=(
-                    self.resolve_path(self._config.ca_cert)
-                    if self._config.ca_cert
-                    else None
-                ),
                 client_cert=(
                     self.resolve_path(self._config.client_cert)
                     if self._config.client_cert
@@ -64,18 +102,8 @@ class ClickhouseOutputPlugin(
                     if self._config.client_cert_key
                     else None
                 ),
-                server_host_name=self._config.server_host_name,
                 tls_mode=self._config.tls_mode,
-                http_proxy=(
-                    str(self._config.proxy_url)
-                    if self._config.proxy_url
-                    else None
-                ),
-                https_proxy=(
-                    str(self._config.proxy_url)
-                    if self._config.proxy_url
-                    else None
-                ),
+                pool_mgr=self._pool_mgr,
             )
         except Exception as e:
             msg = 'Cannot initialize ClickHouse client'
@@ -89,6 +117,7 @@ class ClickhouseOutputPlugin(
     @override
     async def _close(self) -> None:
         await self._client.close()
+        self._pool_mgr.clear()
 
     @override
     async def _write(self, events: Sequence[str]) -> int:

--- a/eventum/plugins/output/plugins/clickhouse/tests/test_config.py
+++ b/eventum/plugins/output/plugins/clickhouse/tests/test_config.py
@@ -8,51 +8,75 @@ from eventum.plugins.output.plugins.clickhouse.config import (
 )
 
 
-def test_minimal_valid():
+def test_minimal_valid() -> None:
+    """Defaults are applied when only required fields are set."""
     config = ClickhouseOutputPluginConfig(host='localhost', table='events')
-    assert config.host == 'localhost'
-    assert config.table == 'events'
-    assert config.port == 8123
-    assert config.database == 'default'
-    assert config.protocol == 'http'
+    assert config.host == 'localhost'  # noqa: S101
+    assert config.table == 'events'  # noqa: S101
+    assert config.port == 8123  # noqa: S101, PLR2004
+    assert config.database == 'default'  # noqa: S101
+    assert config.protocol == 'http'  # noqa: S101
+    assert config.pool_maxsize == 32  # noqa: S101, PLR2004
 
 
-def test_missing_host():
+def test_pool_maxsize_custom() -> None:
+    """Custom `pool_maxsize` value is propagated."""
+    config = ClickhouseOutputPluginConfig(
+        host='localhost', table='events', pool_maxsize=100
+    )
+    assert config.pool_maxsize == 100  # noqa: S101, PLR2004
+
+
+def test_pool_maxsize_must_be_positive() -> None:
+    """`pool_maxsize` below 1 is rejected."""
     with pytest.raises(ValidationError):
-        ClickhouseOutputPluginConfig(table='events')  # type: ignore
+        ClickhouseOutputPluginConfig(
+            host='localhost', table='events', pool_maxsize=0
+        )
 
 
-def test_missing_table():
+def test_missing_host() -> None:
+    """Omitting required `host` triggers validation error."""
     with pytest.raises(ValidationError):
-        ClickhouseOutputPluginConfig(host='localhost')  # type: ignore
+        ClickhouseOutputPluginConfig(table='events')  # type: ignore[call-arg]
 
 
-def test_port_boundary():
+def test_missing_table() -> None:
+    """Omitting required `table` triggers validation error."""
+    with pytest.raises(ValidationError):
+        ClickhouseOutputPluginConfig(host='localhost')  # type: ignore[call-arg]
+
+
+def test_port_boundary() -> None:
+    """Port accepts max value and rejects 0."""
     config = ClickhouseOutputPluginConfig(
         host='localhost', table='events', port=65535
     )
-    assert config.port == 65535
+    assert config.port == 65535  # noqa: S101, PLR2004
 
     with pytest.raises(ValidationError):
         ClickhouseOutputPluginConfig(host='localhost', table='events', port=0)
 
 
-def test_custom_database_and_protocol():
+def test_custom_database_and_protocol() -> None:
+    """Custom database name and HTTPS protocol are propagated."""
     config = ClickhouseOutputPluginConfig(
         host='db.example.com',
         table='logs',
         database='analytics',
         protocol='https',
     )
-    assert config.database == 'analytics'
-    assert config.protocol == 'https'
+    assert config.database == 'analytics'  # noqa: S101
+    assert config.protocol == 'https'  # noqa: S101
 
 
-def test_empty_host_raises():
+def test_empty_host_raises() -> None:
+    """Empty `host` string is rejected."""
     with pytest.raises(ValidationError):
         ClickhouseOutputPluginConfig(host='', table='events')
 
 
-def test_empty_table_raises():
+def test_empty_table_raises() -> None:
+    """Empty `table` string is rejected."""
     with pytest.raises(ValidationError):
         ClickhouseOutputPluginConfig(host='localhost', table='')

--- a/eventum/plugins/output/plugins/clickhouse/tests/test_plugin.py
+++ b/eventum/plugins/output/plugins/clickhouse/tests/test_plugin.py
@@ -1,0 +1,104 @@
+"""Tests for clickhouse output plugin."""
+
+from unittest.mock import patch
+
+from eventum.plugins.output.plugins.clickhouse.config import (
+    ClickhouseOutputPluginConfig,
+)
+from eventum.plugins.output.plugins.clickhouse.plugin import (
+    ClickhouseOutputPlugin,
+)
+
+
+def _make_plugin(**config_overrides: object) -> ClickhouseOutputPlugin:
+    config = ClickhouseOutputPluginConfig(
+        host='localhost',
+        table='events',
+        **config_overrides,  # type: ignore[arg-type]
+    )
+    return ClickhouseOutputPlugin(config=config, params={'id': 1})
+
+
+def test_create_pool_manager_default_maxsize() -> None:
+    """Default `pool_maxsize=32` is forwarded to the pool manager."""
+    plugin = _make_plugin()
+    with patch(
+        'eventum.plugins.output.plugins.clickhouse.plugin.get_pool_manager'
+    ) as mock_pool:
+        plugin._create_pool_manager()  # noqa: SLF001
+
+    options = mock_pool.call_args.kwargs
+    assert options['maxsize'] == 32  # noqa: S101, PLR2004
+    assert options['verify'] is True  # noqa: S101
+    assert 'ca_cert' not in options  # noqa: S101
+    assert 'client_cert' not in options  # noqa: S101
+    assert 'http_proxy' not in options  # noqa: S101
+    assert 'https_proxy' not in options  # noqa: S101
+
+
+def test_create_pool_manager_custom_maxsize() -> None:
+    """Custom `pool_maxsize` overrides the default."""
+    plugin = _make_plugin(pool_maxsize=256)
+    with patch(
+        'eventum.plugins.output.plugins.clickhouse.plugin.get_pool_manager'
+    ) as mock_pool:
+        plugin._create_pool_manager()  # noqa: SLF001
+
+    assert mock_pool.call_args.kwargs['maxsize'] == 256  # noqa: S101, PLR2004
+
+
+def test_create_pool_manager_https_proxy_routed_by_protocol() -> None:
+    """`proxy_url` is routed to `https_proxy` when protocol is HTTPS."""
+    plugin = _make_plugin(
+        protocol='https',
+        proxy_url='https://proxy.example.com',
+    )
+    with patch(
+        'eventum.plugins.output.plugins.clickhouse.plugin.get_pool_manager'
+    ) as mock_pool:
+        plugin._create_pool_manager()  # noqa: SLF001
+
+    options = mock_pool.call_args.kwargs
+    assert options['https_proxy'] == 'https://proxy.example.com/'  # noqa: S101
+    assert 'http_proxy' not in options  # noqa: S101
+
+
+def test_create_pool_manager_http_proxy_routed_by_protocol() -> None:
+    """`proxy_url` is routed to `http_proxy` when protocol is HTTP."""
+    plugin = _make_plugin(proxy_url='http://proxy.example.com')
+    with patch(
+        'eventum.plugins.output.plugins.clickhouse.plugin.get_pool_manager'
+    ) as mock_pool:
+        plugin._create_pool_manager()  # noqa: SLF001
+
+    options = mock_pool.call_args.kwargs
+    assert options['http_proxy'] == 'http://proxy.example.com/'  # noqa: S101
+    assert 'https_proxy' not in options  # noqa: S101
+
+
+def test_create_pool_manager_server_host_name_with_verify() -> None:
+    """`server_host_name` sets both `assert_hostname` and `server_hostname`
+    when verify is enabled.
+    """
+    plugin = _make_plugin(verify=True, server_host_name='ch.internal')
+    with patch(
+        'eventum.plugins.output.plugins.clickhouse.plugin.get_pool_manager'
+    ) as mock_pool:
+        plugin._create_pool_manager()  # noqa: SLF001
+
+    options = mock_pool.call_args.kwargs
+    assert options['assert_hostname'] == 'ch.internal'  # noqa: S101
+    assert options['server_hostname'] == 'ch.internal'  # noqa: S101
+
+
+def test_create_pool_manager_server_host_name_without_verify() -> None:
+    """`server_host_name` skips `assert_hostname` when verify is disabled."""
+    plugin = _make_plugin(verify=False, server_host_name='ch.internal')
+    with patch(
+        'eventum.plugins.output.plugins.clickhouse.plugin.get_pool_manager'
+    ) as mock_pool:
+        plugin._create_pool_manager()  # noqa: SLF001
+
+    options = mock_pool.call_args.kwargs
+    assert 'assert_hostname' not in options  # noqa: S101
+    assert options['server_hostname'] == 'ch.internal'  # noqa: S101

--- a/eventum/ui/src/api/routes/generator-configs/schemas/plugins/output/configs/clickhouse/index.ts
+++ b/eventum/ui/src/api/routes/generator-configs/schemas/plugins/output/configs/clickhouse/index.ts
@@ -27,6 +27,7 @@ export const ClickhouseOutputPluginConfigSchema =
     server_host_name: z.string().min(1).nullable().optional(),
     tls_mode: orPlaceholder(z.enum(TLS_MODES)).nullable().optional(),
     proxy_url: z.string().min(1).nullable().optional(),
+    pool_maxsize: orPlaceholder(z.number().int().gte(1)).optional(),
     input_format: orPlaceholder(z.enum(CLICKHOUSE_INPUT_FORMAT)).optional(),
     header: z.string().optional(),
     footer: z.string().optional(),

--- a/eventum/ui/src/pages/ProjectPage/OutputPluginsTab/OutputPluginParams/ClickhouseOutputPluginParams.tsx
+++ b/eventum/ui/src/pages/ProjectPage/OutputPluginsTab/OutputPluginParams/ClickhouseOutputPluginParams.tsx
@@ -246,25 +246,47 @@ export const ClickhouseOutputPluginParams: FC<
         />
       </Group>
 
-      <TextInput
-        label={
-          <LabelWithTooltip
-            label="Client name"
-            tooltip="Client name that is prepended to the HTTP User Agent header,
+      <Group grow align="start" wrap="nowrap">
+        <TextInput
+          label={
+            <LabelWithTooltip
+              label="Client name"
+              tooltip="Client name that is prepended to the HTTP User Agent header,
               set this to track client queries in the ClickHouse query log"
-          />
-        }
-        placeholder="name"
-        {...form.getInputProps('client_name')}
-        onChange={(value) =>
-          form.setFieldValue(
-            'client_name',
-            value.currentTarget.value !== ''
-              ? value.currentTarget.value
-              : undefined
-          )
-        }
-      />
+            />
+          }
+          placeholder="name"
+          {...form.getInputProps('client_name')}
+          onChange={(value) =>
+            form.setFieldValue(
+              'client_name',
+              value.currentTarget.value !== ''
+                ? value.currentTarget.value
+                : undefined
+            )
+          }
+        />
+        <NumberInput
+          label={
+            <LabelWithTooltip
+              label="Pool max size"
+              tooltip="Maximum number of HTTP connections kept in the pool toward the ClickHouse host, default value is 32. Raise alongside `generation.max_concurrency` to avoid pool exhaustion under bursts of concurrent writes."
+            />
+          }
+          placeholder="connections"
+          min={1}
+          step={1}
+          allowDecimal={false}
+          {...form.getInputProps('pool_maxsize')}
+          value={form.getValues().pool_maxsize ?? ''}
+          onChange={(value) =>
+            form.setFieldValue(
+              'pool_maxsize',
+              typeof value === 'number' ? value : undefined
+            )
+          }
+        />
+      </Group>
 
       <Paper withBorder p="xs">
         <Stack gap="xs">


### PR DESCRIPTION
## Summary

Closes #33.

`clickhouse-connect` builds its urllib3 pool with `maxsize=8` by default. Eventum's output stage runs up to `max_concurrency=100` concurrent writes per generator, so bursts of batches overflow the pool, force fresh TCP/TLS handshakes per request, and emit `Connection pool is full, discarding connection` warnings - making ingest slow even though writes still succeed.

- Add `pool_maxsize` config field on the ClickHouse output plugin (default `32`, `>= 1`).
- Build a dedicated `urllib3.PoolManager` in `_open` with TLS, proxy, and verification options pre-applied (since `clickhouse-connect` skips configuring TLS on a user-supplied pool).
- Pass the pool into `get_async_client(pool_mgr=...)`; clear it in `_close`.
- Mirror the field in the Zod schema and UI form, document it in the plugin reference (separate PR in `docs`), add entry to `CHANGELOG.md`.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy eventum/`
- [x] `uv run pytest --ignore=tests/integration` (946 passed)
- [x] `pnpm build` in `eventum/ui`
- [ ] Manually verify warning is gone under the original repro (`batch_size: 50000`, large ingest burst)

## Notes

- Existing integration tests don't cover the concurrent-write path that triggers the original symptom - worth a follow-up.
- Docs PR: eventum-generator/docs#33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)