### PR TITLE
fix(app): expand dotted config keys at any depth in all YAML configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this project will be documented in this file.
 - **ClickHouse output: `pool_maxsize` parameter** — configure the HTTP connection pool size toward the ClickHouse host (default `32`); raise it together with `generation.max_concurrency` to avoid `Connection pool is full` warnings and connection churn under bursts of concurrent writes
 - **`module.rand.crypto.sha1()`** — generate a random 40-character hex string (SHA-1-length)
 
+### 🐛 Bug Fixes
+
+- **Dot-separated config keys work at any depth, in every YAML file** — previously only the top level of `eventum.yml` understood dotted keys, so a nested spelling like `server: {mcp.enabled: true}` was rejected with `extra inputs are not permitted`. Now `eventum.yml`, generator configs, `startup.yml`, and time-pattern files all accept dotted keys at any nesting level, both spellings can be mixed and are deep-merged, and defining the same key twice fails with the exact conflicting path
+
 ## 2.5.0 (2026-05-14)
 
 ### 🚀 New Features

--- a/eventum/api/routers/generator_configs/routes.py
+++ b/eventum/api/routers/generator_configs/routes.py
@@ -41,6 +41,7 @@ from eventum.api.routers.generator_configs.models import (
     GeneratorDirExtendedInfo,
 )
 from eventum.api.utils.response_description import merge_responses
+from eventum.utils.dotted_keys import DottedKeyError, expand_dotted_keys
 from eventum.utils.fs_utils import (
     calculate_dir_size,
     get_dir_last_modification_time,
@@ -163,6 +164,7 @@ async def get_generator_config(
         config_data = await asyncio.to_thread(
             lambda: yaml.load(stream=raw_yaml, Loader=yaml.SafeLoader),
         )
+        config_data = expand_dotted_keys(config_data)
 
         return GeneratorConfig.model_validate(config_data)
     except OSError as e:
@@ -170,7 +172,7 @@ async def get_generator_config(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=(f'Configuration cannot be read due to OS error: {e}'),
         ) from None
-    except yaml.error.YAMLError as e:
+    except (yaml.error.YAMLError, DottedKeyError) as e:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=(f'Configuration cannot be read due to parsing error: {e}'),

--- a/eventum/api/routers/startup/dependencies.py
+++ b/eventum/api/routers/startup/dependencies.py
@@ -20,6 +20,7 @@ from eventum.app.startup.mapping import (
     RawEntriesValidationError,
     StartupEntryMapper,
 )
+from eventum.utils.dotted_keys import DottedKeyError, expand_dotted_keys
 
 type StartupGeneratorParametersListRaw = list[dict]
 
@@ -71,6 +72,14 @@ async def get_startup_generator_parameters_list(
     parsed_object = await asyncio.to_thread(
         lambda: yaml.load(content, Loader=yaml.SafeLoader),
     )
+
+    try:
+        parsed_object = expand_dotted_keys(parsed_object)
+    except DottedKeyError as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f'Startup file structure is invalid: {e}',
+        ) from None
 
     if not isinstance(parsed_object, list):
         raise HTTPException(

--- a/eventum/api/tests/test_generator_configs.py
+++ b/eventum/api/tests/test_generator_configs.py
@@ -197,6 +197,58 @@ def test_get_config_invalid_yaml(client, tmp_settings):
     assert response.status_code == 422
 
 
+def test_get_config_expands_dotted_keys(
+    client: TestClient,
+    tmp_settings: Settings,
+) -> None:
+    """Dotted spelling is served identically to the nested form."""
+    dotted_config = {
+        'input': [{'cron.expression': '* * * * *', 'cron.count': 1}],
+        'event': {'replay.path': 'events.log'},
+        'output': [{'stdout.formatter.format': 'plain'}],
+    }
+    _create_config(tmp_settings, 'canonical_gen')
+    gen_dir = tmp_settings.path.generators_dir / 'dotted_gen'
+    gen_dir.mkdir()
+    config_path = gen_dir / tmp_settings.path.generator_config_filename
+    config_path.write_text(yaml.dump(dotted_config, sort_keys=False))
+
+    dotted = client.get('/configs/dotted_gen')
+    canonical = client.get('/configs/canonical_gen')
+
+    assert dotted.status_code == 200  # noqa: PLR2004
+    assert dotted.json() == canonical.json()
+
+
+def test_get_config_conflicting_dotted_keys(
+    client: TestClient,
+    tmp_settings: Settings,
+) -> None:
+    """Conflicting spellings yield 422 naming the key path."""
+    gen_dir = tmp_settings.path.generators_dir / 'conflict_gen'
+    gen_dir.mkdir()
+    config_path = gen_dir / tmp_settings.path.generator_config_filename
+    config_path.write_text(
+        'input:\n'
+        '- cron:\n'
+        "    expression: '* * * * *'\n"
+        '    count: 1\n'
+        'event:\n'
+        '  replay.path: a.log\n'
+        '  replay:\n'
+        '    path: b.log\n'
+        'output:\n'
+        '- stdout:\n'
+        '    formatter:\n'
+        '      format: plain\n',
+    )
+
+    response = client.get('/configs/conflict_gen')
+
+    assert response.status_code == 422  # noqa: PLR2004
+    assert 'event.replay.path' in response.json()['detail']
+
+
 # --- POST /{name} ---
 
 

--- a/eventum/api/tests/test_startup.py
+++ b/eventum/api/tests/test_startup.py
@@ -7,6 +7,9 @@ import yaml
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from eventum.api.routers.startup.dependencies import (
+    StartupGeneratorsParametersListDep,
+)
 from eventum.api.routers.startup.routes import router
 from eventum.app.models.parameters.log import LogParameters
 from eventum.app.models.parameters.path import PathParameters
@@ -184,3 +187,60 @@ def test_delete_startup_entry_not_found(
     _write_startup(tmp_settings, [_gen_entry('gen1')])
     response = client.delete('/startup/missing')
     assert response.status_code == 404  # noqa: S101, PLR2004
+
+
+# --- startup parameters dependency (scenarios router) ---
+
+
+def _probe_client(tmp_settings: Settings) -> TestClient:
+    """Build a client with a probe route using the dependency."""
+    app = FastAPI()
+    app.state.settings = tmp_settings
+
+    @app.get('/probe')
+    async def probe(
+        data: StartupGeneratorsParametersListDep,
+    ) -> dict:
+        params_list, raw = data
+        return {
+            'batch_size': params_list.root[0].batch.size,
+            'raw': raw,
+        }
+
+    return TestClient(app)
+
+
+def test_startup_dependency_expands_dotted_keys(
+    tmp_settings: Settings,
+) -> None:
+    """Dotted keys in entries expand for model and raw views."""
+    tmp_settings.path.startup.write_text(
+        '- id: gen-1\n  path: gen-1/generator.yml\n  batch.size: 5\n',
+    )
+
+    with _probe_client(tmp_settings) as client:
+        response = client.get('/probe')
+
+    assert response.status_code == 200  # noqa: S101, PLR2004
+    data = response.json()
+    assert data['batch_size'] == 5  # noqa: S101, PLR2004
+    assert data['raw'][0]['batch'] == {'size': 5}  # noqa: S101
+
+
+def test_startup_dependency_conflicting_dotted_keys(
+    tmp_settings: Settings,
+) -> None:
+    """Conflicting spellings yield 500 naming the key path."""
+    tmp_settings.path.startup.write_text(
+        '- id: gen-1\n'
+        '  path: gen-1/generator.yml\n'
+        '  batch.size: 5\n'
+        '  batch:\n'
+        '    size: 6\n',
+    )
+
+    with _probe_client(tmp_settings) as client:
+        response = client.get('/probe')
+
+    assert response.status_code == 500  # noqa: S101, PLR2004
+    assert '[0].batch.size' in response.json()['detail']  # noqa: S101

--- a/eventum/app/startup/storage.py
+++ b/eventum/app/startup/storage.py
@@ -6,6 +6,7 @@ from typing import Any
 import yaml
 
 from eventum.app.startup.exceptions import StartupError
+from eventum.utils.dotted_keys import DottedKeyError, expand_dotted_keys
 
 
 class StartupFile:
@@ -99,7 +100,8 @@ class StartupFile:
     def _parse(self, content: str) -> list[dict]:
         try:
             parsed = yaml.safe_load(content)
-        except yaml.YAMLError as e:
+            parsed = expand_dotted_keys(parsed)
+        except (yaml.YAMLError, DottedKeyError) as e:
             msg = 'Startup file is not valid YAML'
             raise self._build_error(msg, reason=str(e)) from None
 

--- a/eventum/app/tests/test_startup.py
+++ b/eventum/app/tests/test_startup.py
@@ -16,6 +16,7 @@ from eventum.app.startup import (
     StartupGeneratorParameters,
     StartupNotFoundError,
 )
+from eventum.app.startup.storage import StartupFile
 from eventum.core.parameters import GenerationParameters
 
 
@@ -458,3 +459,43 @@ def test_atomic_write_preserves_symlink(
     assert link.is_symlink()  # noqa: S101
     assert link.resolve() == real  # noqa: S101
     assert 'gen-1' in real.read_text()  # noqa: S101
+
+
+def test_startup_file_read_expands_dotted_keys(
+    settings: Settings,
+) -> None:
+    """Dotted keys in entries are expanded to nested mappings."""
+    _write_startup(
+        settings,
+        '- id: gen-1\n  path: gen-1/generator.yml\n  batch.size: 5\n',
+    )
+
+    entries = StartupFile(file_path=settings.path.startup).read()
+
+    assert entries == [  # noqa: S101
+        {
+            'id': 'gen-1',
+            'path': 'gen-1/generator.yml',
+            'batch': {'size': 5},
+        },
+    ]
+
+
+def test_startup_file_read_raises_on_conflicting_dotted_keys(
+    settings: Settings,
+) -> None:
+    """Conflicting dotted spellings raise StartupError with path."""
+    _write_startup(
+        settings,
+        '- id: gen-1\n'
+        '  path: gen-1/generator.yml\n'
+        '  batch.size: 5\n'
+        '  batch:\n'
+        '    size: 6\n',
+    )
+
+    with pytest.raises(StartupError) as exc:
+        StartupFile(file_path=settings.path.startup).read()
+
+    assert '[0].batch.size' in exc.value.context['reason']  # noqa: S101
+    assert exc.value.context['file_path'] == str(settings.path.startup)  # noqa: S101

--- a/eventum/cli/commands/eventum.py
+++ b/eventum/cli/commands/eventum.py
@@ -9,7 +9,6 @@ from typing import Literal, NoReturn
 import click
 import structlog
 import yaml
-from flatten_dict import unflatten  # type: ignore[import-untyped]
 from pydantic import ValidationError
 from setproctitle import setproctitle
 
@@ -25,6 +24,7 @@ from eventum.cli.splash_screen import SPLASH_SCREEN
 from eventum.core.generator import Generator
 from eventum.core.parameters import GeneratorParameters
 from eventum.security.manage import SECURITY_SETTINGS
+from eventum.utils.dotted_keys import DottedKeyError, expand_dotted_keys
 from eventum.utils.validation_prettier import prettify_validation_errors
 
 setproctitle('eventum')
@@ -52,7 +52,8 @@ def _start_app_instance(config: str) -> App:
         with config_path.open() as f:
             try:
                 data = yaml.load(f, Loader=yaml.SafeLoader)
-            except yaml.error.YAMLError as e:
+                data = expand_dotted_keys(data)
+            except (yaml.error.YAMLError, DottedKeyError) as e:
                 click.echo(
                     f'Error: Failed to parse configuration YAML content: {e}',
                     err=True,
@@ -64,8 +65,6 @@ def _start_app_instance(config: str) -> App:
             err=True,
         )
         sys.exit(1)
-
-    data = unflatten(data, splitter='dot')
 
     try:
         settings = Settings.model_validate(data)

--- a/eventum/cli/commands/service.py
+++ b/eventum/cli/commands/service.py
@@ -16,6 +16,7 @@ from eventum.cli.service_manager import (
     ServicePaths,
     ServiceStatus,
 )
+from eventum.utils.dotted_keys import DottedKeyError, expand_dotted_keys
 
 
 def _default_config_dir(*, user_mode: bool) -> Path:
@@ -312,9 +313,12 @@ def _extract_log_dir(
     try:
         with svc_status.config_file.open() as f:
             data = yaml.load(f, Loader=yaml.SafeLoader)
-        if isinstance(data, dict) and 'path.logs' in data:
-            return Path(data['path.logs'])
-    except OSError, yaml.error.YAMLError:
+        data = expand_dotted_keys(data)
+        if isinstance(data, dict):
+            path_params = data.get('path')
+            if isinstance(path_params, dict) and 'logs' in path_params:
+                return Path(path_params['logs'])
+    except OSError, yaml.error.YAMLError, DottedKeyError:
         click.echo(
             f'Warning: Could not read {svc_status.config_file}, '
             'log directory will not be purged.',

--- a/eventum/cli/tests/test_commands_eventum.py
+++ b/eventum/cli/tests/test_commands_eventum.py
@@ -1,0 +1,96 @@
+"""Tests for eventum CLI app startup commands."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from eventum.app.models.parameters.server import MCPParameters
+from eventum.app.models.settings import Settings
+
+DOTTED_SERVER_SECTION = (
+    'server:\n'
+    '  mcp.enabled: true\n'
+    '  mcp.allow_write: true\n'
+    "  mcp.path: '/mcp'\n"
+)
+
+NESTED_SERVER_SECTION = (
+    'server:\n'
+    '  mcp:\n'
+    '    enabled: true\n'
+    '    allow_write: true\n'
+    "    path: '/mcp'\n"
+)
+
+CONFLICTING_SERVER_SECTION = (
+    'server:\n  mcp.enabled: true\n  mcp:\n    enabled: false\n'
+)
+
+
+def _write_config(
+    tmp_path: Path,
+    server_section: str,
+    name: str,
+) -> Path:
+    """Write a minimal eventum.yml with the given server section."""
+    config_path = tmp_path / name
+    config_path.write_text(
+        server_section + 'generation: {}\n'
+        'log: {}\n'
+        'path:\n'
+        f'  logs: {tmp_path / "logs"}\n'
+        f'  startup: {tmp_path / "startup.yml"}\n'
+        f'  generators_dir: {tmp_path / "generators"}\n'
+        f'  keyring_cryptfile: {tmp_path / "keyring.dat"}\n',
+    )
+    return config_path
+
+
+def _start_app(config_path: Path) -> Settings:
+    """Run _start_app_instance with app and logging mocked."""
+    from eventum.cli.commands.eventum import _start_app_instance
+
+    with (
+        patch('eventum.cli.commands.eventum.App') as mock_app,
+        patch('eventum.cli.commands.eventum.logconf'),
+    ):
+        _start_app_instance(str(config_path))
+
+    return mock_app.call_args.kwargs['settings']
+
+
+def test_start_app_instance_expands_dotted_keys(tmp_path: Path) -> None:
+    """Dotted server.mcp spelling loads same as the nested form."""
+    dotted = _write_config(tmp_path, DOTTED_SERVER_SECTION, 'dotted.yml')
+    nested = _write_config(tmp_path, NESTED_SERVER_SECTION, 'nested.yml')
+
+    dotted_settings = _start_app(dotted)
+    nested_settings = _start_app(nested)
+
+    assert dotted_settings.server.mcp == MCPParameters(
+        enabled=True,
+        allow_write=True,
+        path='/mcp',
+    )
+    assert dotted_settings == nested_settings
+
+
+def test_start_app_instance_conflicting_dotted_keys(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Conflicting spellings exit with an error naming the path."""
+    config_path = _write_config(
+        tmp_path,
+        CONFLICTING_SERVER_SECTION,
+        'conflicting.yml',
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        _start_app(config_path)
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert 'Failed to parse configuration YAML content' in captured.err
+    assert 'server.mcp.enabled' in captured.err

--- a/eventum/cli/tests/test_commands_service.py
+++ b/eventum/cli/tests/test_commands_service.py
@@ -442,3 +442,60 @@ def test_status_installed_inactive(mock_euid, _mock_service_manager, runner):
     assert result.exit_code == 0
     assert 'installed' in result.output
     assert 'inactive' in result.output
+
+
+# --- _extract_log_dir ---
+
+
+def _installed_status(config_file: Path) -> ServiceStatus:
+    """Build an installed ServiceStatus pointing at config_file."""
+    return ServiceStatus(
+        installed=True,
+        active=False,
+        enabled=False,
+        unit_file=Path('/etc/systemd/system/eventum.service'),
+        config_file=config_file,
+        user_mode=False,
+    )
+
+
+def test_extract_log_dir_flat_dotted_config(tmp_path: Path) -> None:
+    """Flat dotted path.logs key of installed config is read."""
+    from eventum.cli.commands.service import _extract_log_dir
+
+    config_file = tmp_path / 'eventum.yml'
+    config_file.write_text('path.logs: /var/log/eventum\n')
+
+    result = _extract_log_dir(_installed_status(config_file))
+
+    assert result == Path('/var/log/eventum')
+
+
+def test_extract_log_dir_nested_config(tmp_path: Path) -> None:
+    """Nested path.logs spelling is read same as the flat one."""
+    from eventum.cli.commands.service import _extract_log_dir
+
+    config_file = tmp_path / 'eventum.yml'
+    config_file.write_text('path:\n  logs: /var/log/eventum\n')
+
+    result = _extract_log_dir(_installed_status(config_file))
+
+    assert result == Path('/var/log/eventum')
+
+
+def test_extract_log_dir_conflicting_dotted_keys(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Conflicting spellings warn and skip log dir extraction."""
+    from eventum.cli.commands.service import _extract_log_dir
+
+    config_file = tmp_path / 'eventum.yml'
+    config_file.write_text(
+        'path.logs: /var/log/eventum\npath:\n  logs: /var/log/other\n',
+    )
+
+    result = _extract_log_dir(_installed_status(config_file))
+
+    assert result is None
+    assert 'Warning: Could not read' in capsys.readouterr().err

--- a/eventum/core/config_loader.py
+++ b/eventum/core/config_loader.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError
 from eventum.core.config import GeneratorConfig
 from eventum.exceptions import ContextualError
 from eventum.security.manage import get_secret
+from eventum.utils.dotted_keys import DottedKeyError, expand_dotted_keys
 from eventum.utils.validation_prettier import prettify_validation_errors
 
 logger = structlog.stdlib.get_logger()
@@ -357,7 +358,8 @@ def load(path: Path, params: dict[str, Any]) -> GeneratorConfig:
     logger.debug('Parsing yaml content of config')
     try:
         config_data = yaml.load(substituted_content, yaml.SafeLoader)
-    except yaml.error.YAMLError as e:
+        config_data = expand_dotted_keys(config_data)
+    except (yaml.error.YAMLError, DottedKeyError) as e:
         msg = 'Failed to parse configuration YAML content'
         raise ConfigurationLoadError(
             msg,

--- a/eventum/core/tests/static/conflicting_dotted_keys_config.yml
+++ b/eventum/core/tests/static/conflicting_dotted_keys_config.yml
@@ -1,0 +1,14 @@
+input:
+  - cron:
+      expression: "*/5 * * * *"
+      count: 1
+
+event:
+  replay:
+    path: "events.log"
+
+output:
+  - stdout:
+      formatter.format: plain
+      formatter:
+        format: json

--- a/eventum/core/tests/static/dotted_keys_config.yml
+++ b/eventum/core/tests/static/dotted_keys_config.yml
@@ -1,0 +1,16 @@
+input:
+  - cron:
+      expression: "*/5 * * * *"
+      count: 1
+
+event:
+  template.mode: all
+  template:
+    params: {}
+    samples: {}
+    templates:
+      - test.template: "test.jinja"
+
+output:
+  - stdout:
+      formatter.format: plain

--- a/eventum/core/tests/test_config.py
+++ b/eventum/core/tests/test_config.py
@@ -13,6 +13,10 @@ INVALID_YAML_CONFIG_PATH = BASE_PATH / 'static' / 'invalid_yaml_config.yml'
 INVALID_STRUCTURE_CONFIG_PATH = (
     BASE_PATH / 'static' / 'invalid_structure_config.yml'
 )
+DOTTED_KEYS_CONFIG_PATH = BASE_PATH / 'static' / 'dotted_keys_config.yml'
+CONFLICTING_DOTTED_KEYS_CONFIG_PATH = (
+    BASE_PATH / 'static' / 'conflicting_dotted_keys_config.yml'
+)
 
 
 def test_load():
@@ -45,3 +49,32 @@ def test_invalid_config_structure():
 def test_missing_parameters():
     with pytest.raises(ConfigurationLoadError):
         load(path=CONFIG_PATH, params={})
+
+
+def test_load_expands_dotted_keys() -> None:
+    """Dotted spellings load identically to the nested form."""
+    config = load(path=DOTTED_KEYS_CONFIG_PATH, params={})
+
+    canonical = GeneratorConfig.model_validate(
+        {
+            'input': [{'cron': {'expression': '*/5 * * * *', 'count': 1}}],
+            'event': {
+                'template': {
+                    'mode': 'all',
+                    'params': {},
+                    'samples': {},
+                    'templates': [{'test': {'template': 'test.jinja'}}],
+                },
+            },
+            'output': [{'stdout': {'formatter': {'format': 'plain'}}}],
+        },
+    )
+    assert config == canonical
+
+
+def test_load_conflicting_dotted_keys() -> None:
+    """Conflicting spellings raise with the key path in reason."""
+    with pytest.raises(ConfigurationLoadError) as exc:
+        load(path=CONFLICTING_DOTTED_KEYS_CONFIG_PATH, params={})
+
+    assert 'output[0].stdout.formatter.format' in exc.value.context['reason']

--- a/eventum/plugins/input/plugins/time_patterns/plugin.py
+++ b/eventum/plugins/input/plugins/time_patterns/plugin.py
@@ -30,6 +30,7 @@ from eventum.plugins.input.utils.time_utils import (
     skip_periods,
     to_naive,
 )
+from eventum.utils.dotted_keys import DottedKeyError, expand_dotted_keys
 
 if TYPE_CHECKING:
     from eventum.plugins.input.protocols import (
@@ -371,6 +372,7 @@ class TimePatternsInputPlugin(
                 with resolved_pattern_path.open() as f:
                     time_pattern_obj = yaml.load(f, yaml.SafeLoader)
 
+                time_pattern_obj = expand_dotted_keys(time_pattern_obj)
                 time_pattern = TimePatternConfig.model_validate(
                     obj=time_pattern_obj,
                 )
@@ -383,7 +385,7 @@ class TimePatternsInputPlugin(
                         'reason': str(e),
                     },
                 ) from None
-            except yaml.error.YAMLError as e:
+            except (yaml.error.YAMLError, DottedKeyError) as e:
                 msg = 'Failed to parse time pattern configuration'
                 raise PluginConfigurationError(
                     msg,

--- a/eventum/plugins/input/plugins/time_patterns/tests/static/pattern_conflicting.yml
+++ b/eventum/plugins/input/plugins/time_patterns/tests/static/pattern_conflicting.yml
@@ -1,0 +1,17 @@
+label: Conflicting time pattern
+oscillator.start: "now"
+oscillator:
+  start: "2024-01-01T00:00:00.000Z"
+  end: +1s
+  period: 0.1
+  unit: seconds
+multiplier:
+  ratio: 10000
+randomizer:
+  deviation: 0.1
+  direction: mixed
+spreader:
+  distribution: beta
+  parameters:
+    a: 5
+    b: 5

--- a/eventum/plugins/input/plugins/time_patterns/tests/static/pattern_dotted.yml
+++ b/eventum/plugins/input/plugins/time_patterns/tests/static/pattern_dotted.yml
@@ -1,0 +1,14 @@
+label: Time pattern 1
+oscillator.start: "now"
+oscillator.end: +1s
+oscillator:
+  period: 0.1
+  unit: seconds
+multiplier.ratio: 10000
+randomizer:
+  deviation: 0.1
+  direction: mixed
+spreader.distribution: beta
+spreader.parameters:
+  a: 5
+  b: 5

--- a/eventum/plugins/input/plugins/time_patterns/tests/test_plugin.py
+++ b/eventum/plugins/input/plugins/time_patterns/tests/test_plugin.py
@@ -65,3 +65,39 @@ def test_time_pattern_invalid_config():
         TimePatternsInputPlugin(
             config=config, params={'id': 1, 'timezone': ZoneInfo('UTC')}
         )
+
+
+def test_time_pattern_dotted_keys_config():
+    params = {'id': 1, 'timezone': ZoneInfo('UTC')}
+
+    dotted_plugin = TimePatternsInputPlugin(
+        config=TimePatternsInputPluginConfig(
+            patterns=[STATIC_FILES_DIR / 'pattern_dotted.yml'],
+        ),
+        params=params,
+    )
+    canonical_plugin = TimePatternsInputPlugin(
+        config=TimePatternsInputPluginConfig(
+            patterns=[STATIC_FILES_DIR / 'pattern1.yml'],
+        ),
+        params=params,
+    )
+
+    dotted_config = dotted_plugin._time_patterns[0].config
+    canonical_config = canonical_plugin._time_patterns[0].config
+    assert dotted_config == canonical_config
+
+
+def test_time_pattern_conflicting_dotted_keys_config():
+    config = TimePatternsInputPluginConfig(
+        patterns=[
+            STATIC_FILES_DIR / 'pattern_conflicting.yml',
+        ]
+    )
+
+    with pytest.raises(PluginConfigurationError) as exc:
+        TimePatternsInputPlugin(
+            config=config, params={'id': 1, 'timezone': ZoneInfo('UTC')}
+        )
+
+    assert 'oscillator.start' in exc.value.context['reason']

--- a/eventum/utils/dotted_keys.py
+++ b/eventum/utils/dotted_keys.py
@@ -1,0 +1,134 @@
+"""Expansion of dot-separated mapping keys in parsed YAML data."""
+
+from typing import Any
+
+
+class DottedKeyError(ValueError):
+    """Conflict during expansion of dot-separated mapping keys.
+
+    Raised when two spellings of the same key path produce
+    conflicting values: the same leaf is written more than once
+    (e.g. `a.b: 1` together with `a: {b: 2}`) or a dotted path
+    traverses a key that holds a non-mapping value (e.g. `a: 5`
+    together with `a.b: 1`). The message contains the offending
+    key path.
+    """
+
+
+def expand_dotted_keys(value: Any) -> Any:
+    """Expand dot-separated mapping keys into nested mappings.
+
+    Every string key containing a dot is treated as a path of
+    nested mapping keys: `{'a.b': 1}` becomes `{'a': {'b': 1}}`.
+    Expansion is applied recursively to mapping values and list
+    items, so dotted keys work at any depth of the structure.
+    Entries spelled differently but sharing a path prefix are
+    deep-merged: `{'a.b': 1, 'a': {'c': 2}}` becomes
+    `{'a': {'b': 1, 'c': 2}}`.
+
+    Non-string keys and string keys with empty path segments
+    (e.g. `'a.'` or `'.b'`) are kept as is. Scalar values are
+    returned unchanged and explicit empty mappings are preserved.
+    The input is not mutated: expanded mappings and lists are new
+    objects.
+
+    Parameters
+    ----------
+    value : Any
+        Parsed YAML data to expand.
+
+    Returns
+    -------
+    Any
+        Expanded data.
+
+    Raises
+    ------
+    DottedKeyError
+        If two spellings produce conflicting values for the same
+        key path.
+
+    """
+    return _expand(value, path='')
+
+
+def _join_key(path: str, key: Any) -> str:
+    """Append a mapping key segment to a path."""
+    if not path:
+        return str(key)
+    return f'{path}.{key}'
+
+
+def _join_index(path: str, index: int) -> str:
+    """Append a list index segment to a path."""
+    return f'{path}[{index}]'
+
+
+def _split_key(key: Any) -> list[Any]:
+    """Split a key on dots if it is an expandable string key."""
+    if not isinstance(key, str) or '.' not in key:
+        return [key]
+
+    parts = key.split('.')
+    if any(not part for part in parts):
+        return [key]
+
+    return parts
+
+
+def _expand(value: Any, path: str) -> Any:
+    """Recursively expand a parsed YAML node."""
+    if isinstance(value, dict):
+        result: dict[Any, Any] = {}
+
+        for key, item in value.items():
+            parts = _split_key(key)
+
+            leaf_path = path
+            for part in parts:
+                leaf_path = _join_key(leaf_path, part)
+
+            entry: Any = _expand(item, leaf_path)
+            for part in reversed(parts[1:]):
+                entry = {part: entry}
+
+            head = parts[0]
+            if head in result:
+                result[head] = _merge(
+                    result[head],
+                    entry,
+                    _join_key(path, head),
+                )
+            else:
+                result[head] = entry
+
+        return result
+
+    if isinstance(value, list):
+        return [
+            _expand(item, _join_index(path, index))
+            for index, item in enumerate(value)
+        ]
+
+    return value
+
+
+def _merge(existing: Any, incoming: Any, path: str) -> Any:
+    """Deep-merge two expanded values, raising on conflicts."""
+    if isinstance(existing, dict) and isinstance(incoming, dict):
+        merged = dict(existing)
+
+        for key, value in incoming.items():
+            if key in merged:
+                merged[key] = _merge(
+                    merged[key],
+                    value,
+                    _join_key(path, key),
+                )
+            else:
+                merged[key] = value
+
+        return merged
+
+    msg = f'Conflicting values for key `{path}`'
+    raise DottedKeyError(msg)

--- a/eventum/utils/tests/test_dotted_keys.py
+++ b/eventum/utils/tests/test_dotted_keys.py
@@ -1,0 +1,141 @@
+"""Tests for dotted keys expansion."""
+
+from typing import Any
+
+import pytest
+
+from eventum.utils.dotted_keys import DottedKeyError, expand_dotted_keys
+
+
+def test_expands_dotted_key_at_root() -> None:
+    """Dotted key at the root expands to a nested mapping."""
+    assert expand_dotted_keys({'a.b': 1}) == {'a': {'b': 1}}
+
+
+def test_expands_dotted_key_inside_nested_mapping() -> None:
+    """Dotted key inside a nested mapping expands."""
+    data = {'server': {'mcp.enabled': True}}
+    expected = {'server': {'mcp': {'enabled': True}}}
+    assert expand_dotted_keys(data) == expected
+
+
+def test_expands_multi_segment_key() -> None:
+    """Key with several dots expands to a chain of mappings."""
+    data = {'a.b.c.d': 1}
+    expected = {'a': {'b': {'c': {'d': 1}}}}
+    assert expand_dotted_keys(data) == expected
+
+
+def test_merges_mixed_spellings() -> None:
+    """Dotted and nested spellings of one section deep-merge."""
+    data = {
+        'server': {
+            'mcp.enabled': True,
+            'mcp': {'path': '/mcp'},
+            'host': 'localhost',
+        },
+    }
+    expected = {
+        'server': {
+            'mcp': {'enabled': True, 'path': '/mcp'},
+            'host': 'localhost',
+        },
+    }
+    assert expand_dotted_keys(data) == expected
+
+
+def test_merges_sibling_dotted_keys() -> None:
+    """Sibling dotted keys sharing a prefix merge into one mapping."""
+    data = {'a.b': 1, 'a.c': 2}
+    assert expand_dotted_keys(data) == {'a': {'b': 1, 'c': 2}}
+
+
+def test_recurses_into_list_items() -> None:
+    """Mappings inside lists are expanded."""
+    data = {'output': [{'stdout.formatter.format': 'plain'}]}
+    expected = {'output': [{'stdout': {'formatter': {'format': 'plain'}}}]}
+    assert expand_dotted_keys(data) == expected
+
+
+def test_root_list_items_expanded() -> None:
+    """Items of a root-level list are expanded."""
+    data = [{'a.b': 1}, {'c': 2}]
+    assert expand_dotted_keys(data) == [{'a': {'b': 1}}, {'c': 2}]
+
+
+def test_non_string_keys_untouched() -> None:
+    """Non-string keys are kept as is, their values still expand."""
+    data = {1: {'a.b': 1}, None: 2}
+    expected = {1: {'a': {'b': 1}}, None: 2}
+    assert expand_dotted_keys(data) == expected
+
+
+def test_keys_with_empty_segments_untouched() -> None:
+    """Keys with empty path segments are not split."""
+    data = {'a.': 1, '.b': 2, 'c..d': 3, '.': 4}
+    assert expand_dotted_keys(data) == data
+
+
+def test_preserves_explicit_empty_mapping() -> None:
+    """Explicit empty mapping survives expansion."""
+    assert expand_dotted_keys({'a.b': {}}) == {'a': {'b': {}}}
+
+
+def test_empty_mapping_merges_with_sibling() -> None:
+    """Empty mapping merges into a non-empty sibling spelling."""
+    data = {'a.b': {}, 'a': {'b': {'c': 1}}}
+    assert expand_dotted_keys(data) == {'a': {'b': {'c': 1}}}
+
+
+@pytest.mark.parametrize(
+    'value',
+    [None, 1, 3.14, True, 'a.b', [], {}],
+)
+def test_scalars_and_empty_containers_pass_through(value: Any) -> None:
+    """Scalar values and empty containers pass through unchanged."""
+    assert expand_dotted_keys(value) == value
+
+
+def test_input_not_mutated() -> None:
+    """Expansion returns new structures and keeps the input intact."""
+    data = {'a.b': {'c.d': 1}, 'e': [{'f.g': 2}]}
+    expand_dotted_keys(data)
+    assert data == {'a.b': {'c.d': 1}, 'e': [{'f.g': 2}]}
+
+
+def test_conflict_same_leaf_two_paths() -> None:
+    """Two spellings writing the same leaf raise with the path."""
+    data = {'a.b': 1, 'a': {'b': 2}}
+    with pytest.raises(DottedKeyError) as exc:
+        expand_dotted_keys(data)
+
+    assert '`a.b`' in str(exc.value)
+
+
+def test_conflict_path_through_non_mapping() -> None:
+    """Dotted path through a non-mapping raises with the path."""
+    data = {'a': 5, 'a.b': 1}
+    with pytest.raises(DottedKeyError) as exc:
+        expand_dotted_keys(data)
+
+    assert '`a`' in str(exc.value)
+
+
+def test_conflict_path_includes_list_index() -> None:
+    """Conflict inside a list item reports the indexed path."""
+    data = {
+        'output': [{'stdout.format': 'plain', 'stdout': {'format': 'json'}}],
+    }
+    with pytest.raises(DottedKeyError) as exc:
+        expand_dotted_keys(data)
+
+    assert '`output[0].stdout.format`' in str(exc.value)
+
+
+def test_conflict_under_nested_mapping_reports_full_path() -> None:
+    """Conflict below the root reports the full key path."""
+    data = {'server': {'mcp.enabled': True, 'mcp': {'enabled': False}}}
+    with pytest.raises(DottedKeyError) as exc:
+        expand_dotted_keys(data)
+
+    assert '`server.mcp.enabled`' in str(exc.value)


### PR DESCRIPTION
## Summary

Dot-separated keys now work as a nesting shorthand at **any depth** in **every** YAML config Eventum loads. Previously only the top level of `eventum.yml` was unflattened, so a natural spelling like:

```yaml
server:
  mcp.enabled: true
```

failed with `"server.mcp.enabled": extra inputs are not permitted` — the dotted key inside a nested block was passed to validation literally.

> **Stacked on #139.** Based on `feat/mcp-core-foundations`, so the diff shows only this fix. When #139 merges and its branch is deleted, GitHub retargets this PR to `develop` automatically.

## Design

- New `eventum/utils/dotted_keys.py`: `expand_dotted_keys()` recursively expands dotted mapping keys through mappings and list items, deep-merging mixed spellings (`a.b: 1` + `a: {c: 2}` → `a: {b: 1, c: 2}`). Defining the same path twice raises `DottedKeyError` with the exact conflicting path, list indices included (`output[0].stdout.formatter.format`). Non-string keys and keys with empty dot segments stay literal; input is never mutated; explicit empty mappings survive.
- Applied at all seven YAML load sites, with the error translated per layer's convention:

| Document | Sites |
|---|---|
| `eventum.yml` | CLI `run` (replaces the old top-level-only `unflatten`), `service` log-dir extraction |
| `generator.yml` | core config loader, API config parser |
| `startup.yml` | startup storage, API startup dependency |
| time patterns | `time_patterns` input plugin |

`git grep` confirms no other non-test YAML loaders exist.

## Behavior note

A literal dot in a free-form mapping key (e.g. a template alias `my.alias`) is now interpreted as nesting in all configs — inherent to the feature. Ambiguous double definitions fail loudly with the key path; there are no silent reinterpretations that lose data.

## Testing

- +38 tests, **1234 pass** (`-m "not integration and not performance and not e2e"`); `ruff` / `ruff format` / `mypy` clean.
- 23 utility tests (depth, merge, lists, conflicts, non-string keys, no-mutation) + per-site tests including the exact `eventum.yml` reproduction and conflict-error paths.
- CHANGELOG entry under Unreleased bug fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
