### PR TITLE
fix(app): close streaming connections on graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### 🐛 Bug Fixes
+
+- **Stopping the app no longer hangs when a log or MCP stream is open** — pressing Ctrl+C while a generator's live log view or a connected MCP client is streaming now shuts the app down in well under a second, instead of waiting out the graceful-shutdown timeout and printing cancellation errors on exit
+
 ## 2.6.0 (2026-06-11)
 
 ### 🚀 New Features

--- a/eventum/api/routers/generators/routes.py
+++ b/eventum/api/routers/generators/routes.py
@@ -10,7 +10,6 @@ from fastapi import (
     Path,
     Query,
     WebSocket,
-    WebSocketDisconnect,
     WebSocketException,
     status,
 )
@@ -34,7 +33,7 @@ from eventum.api.routers.generators.models import (
     InputPluginStats,
     OutputPluginStats,
 )
-from eventum.api.utils.file_streaming import stream_file
+from eventum.api.utils.log_streaming import stream_log_file_to_websocket
 from eventum.api.utils.response_description import merge_responses
 from eventum.api.utils.websocket_annotations import (
     AsyncAPIMessage,
@@ -457,15 +456,8 @@ async def stream_generator_logs(
             reason='Log file does not exist',
         )
 
-    try:
-        async for content in stream_file(path=path, end_offset=end_offset):
-            try:
-                await websocket.send_text(content)
-            except WebSocketDisconnect:
-                break
-    except OSError as e:
-        if websocket.client_state.name == 'CONNECTED':
-            raise WebSocketException(
-                code=status.WS_1011_INTERNAL_ERROR,
-                reason=f'Failed to read log file due to OS error: {e}',
-            ) from None
+    await stream_log_file_to_websocket(
+        websocket=websocket,
+        path=path,
+        end_offset=end_offset,
+    )

--- a/eventum/api/routers/instance/routes.py
+++ b/eventum/api/routers/instance/routes.py
@@ -11,14 +11,13 @@ from fastapi import (
     HTTPException,
     Query,
     WebSocket,
-    WebSocketDisconnect,
     WebSocketException,
     status,
 )
 
 from eventum.api.dependencies.app import InstanceHooksDep, SettingsDep
 from eventum.api.routers.instance.models import InstanceInfo
-from eventum.api.utils.file_streaming import stream_file
+from eventum.api.utils.log_streaming import stream_log_file_to_websocket
 from eventum.api.utils.websocket_annotations import (
     AsyncAPIMessage,
     Receives,
@@ -162,15 +161,8 @@ async def stream_main_logs(
             reason='Log file does not exist',
         )
 
-    try:
-        async for content in stream_file(path=path, end_offset=end_offset):
-            try:
-                await websocket.send_text(content)
-            except WebSocketDisconnect:
-                break
-    except OSError as e:
-        if websocket.client_state.name == 'CONNECTED':
-            raise WebSocketException(
-                code=status.WS_1011_INTERNAL_ERROR,
-                reason=f'Failed to read log file due to OS error: {e}',
-            ) from None
+    await stream_log_file_to_websocket(
+        websocket=websocket,
+        path=path,
+        end_offset=end_offset,
+    )

--- a/eventum/api/utils/file_streaming.py
+++ b/eventum/api/utils/file_streaming.py
@@ -1,15 +1,28 @@
 """File streaming utils."""
 
 import asyncio
+import contextlib
 import os
 from collections.abc import AsyncIterator
 from pathlib import Path
 
 import aiofiles
 
+_IDLE_POLL_INTERVAL = 0.5
 
-async def stream_file(path: Path, end_offset: int) -> AsyncIterator[str]:
-    """Stream file from the end.
+
+async def stream_file(
+    path: Path,
+    end_offset: int,
+    stop: asyncio.Event,
+) -> AsyncIterator[str]:
+    """Stream file from the end until stopped.
+
+    Tails the file from ``end_offset`` bytes before its end, yielding
+    new content as it is appended. When no new content is available the
+    call idles, waking on the poll interval or as soon as ``stop`` is
+    set, so the stream terminates promptly on disconnect or shutdown
+    instead of being force-cancelled mid-read.
 
     Parameters
     ----------
@@ -18,6 +31,10 @@ async def stream_file(path: Path, end_offset: int) -> AsyncIterator[str]:
 
     end_offset : int
         Offset from the end of file to start streaming from.
+
+    stop : asyncio.Event
+        Signals the stream to terminate. Checked before each read and
+        interrupts the idle wait.
 
     Yields
     ------
@@ -36,9 +53,15 @@ async def stream_file(path: Path, end_offset: int) -> AsyncIterator[str]:
         start_pos = max(0, size - end_offset)
         await f.seek(start_pos, os.SEEK_SET)
 
-        while True:
+        while not stop.is_set():
             content = await f.read(8192)
             if content:
                 yield content
             else:
-                await asyncio.sleep(0.5)
+                await _idle_wait(stop)
+
+
+async def _idle_wait(stop: asyncio.Event) -> None:
+    """Idle for the poll interval, returning early once stop is set."""
+    with contextlib.suppress(TimeoutError):
+        await asyncio.wait_for(stop.wait(), timeout=_IDLE_POLL_INTERVAL)

--- a/eventum/api/utils/log_streaming.py
+++ b/eventum/api/utils/log_streaming.py
@@ -1,0 +1,83 @@
+"""Stream a log file to a WebSocket until disconnect or shutdown."""
+
+import asyncio
+import contextlib
+from pathlib import Path
+
+from fastapi import (
+    WebSocket,
+    WebSocketDisconnect,
+    WebSocketException,
+    status,
+)
+
+from eventum.api.utils.file_streaming import stream_file
+
+
+async def stream_log_file_to_websocket(
+    websocket: WebSocket,
+    path: Path,
+    end_offset: int,
+) -> None:
+    """Tail a log file to the websocket until disconnect or shutdown.
+
+    A concurrent watcher reads from the socket so a peer disconnect or a
+    server-initiated close is noticed even while the tail idles between
+    reads. The stream then ends cooperatively and the file closes
+    cleanly, instead of being force-cancelled mid-read on shutdown.
+
+    Parameters
+    ----------
+    websocket : WebSocket
+        Accepted websocket to stream chunks to.
+
+    path : Path
+        Path to the log file to tail.
+
+    end_offset : int
+        Offset from the end of the file to start streaming from.
+
+    Raises
+    ------
+    WebSocketException
+        With ``WS_1011_INTERNAL_ERROR`` if the log file cannot be read
+        while the peer is still connected.
+
+    """
+    stop = asyncio.Event()
+    watcher = asyncio.create_task(_watch_disconnect(websocket, stop))
+    try:
+        async for content in stream_file(path, end_offset, stop):
+            try:
+                await websocket.send_text(content)
+            except WebSocketDisconnect, RuntimeError:
+                # A send failing here means the peer is already gone:
+                # WebSocketDisconnect on a clean close, or a RuntimeError
+                # from the ASGI server when the disconnect the watcher
+                # observed raced ahead of this send.
+                break
+    except OSError as e:
+        if websocket.client_state.name == 'CONNECTED':
+            raise WebSocketException(
+                code=status.WS_1011_INTERNAL_ERROR,
+                reason=f'Failed to read log file due to OS error: {e}',
+            ) from None
+    finally:
+        stop.set()
+        watcher.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await watcher
+
+
+async def _watch_disconnect(
+    websocket: WebSocket,
+    stop: asyncio.Event,
+) -> None:
+    """Set ``stop`` as soon as the websocket peer disconnects."""
+    try:
+        while True:
+            message = await websocket.receive()
+            if message['type'] == 'websocket.disconnect':
+                return
+    finally:
+        stop.set()

--- a/eventum/api/utils/tests/__init__.py
+++ b/eventum/api/utils/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for API utilities."""

--- a/eventum/api/utils/tests/test_file_streaming.py
+++ b/eventum/api/utils/tests/test_file_streaming.py
@@ -1,0 +1,82 @@
+"""Tests for file streaming utils."""
+
+import asyncio
+from pathlib import Path
+
+from eventum.api.utils.file_streaming import stream_file
+
+
+async def test_streams_existing_tail(tmp_path: Path) -> None:
+    """Content within the end offset is yielded from the tail."""
+    log = tmp_path / 'log.txt'
+    log.write_text('hello world')
+    stop = asyncio.Event()
+
+    chunks: list[str] = []
+    async for chunk in stream_file(path=log, end_offset=5, stop=stop):
+        chunks.append(chunk)
+        stop.set()
+
+    assert ''.join(chunks) == 'world'
+
+
+async def test_stop_already_set_yields_nothing(tmp_path: Path) -> None:
+    """A stop set before iteration terminates without yielding."""
+    log = tmp_path / 'log.txt'
+    log.write_text('data')
+    stop = asyncio.Event()
+    stop.set()
+
+    chunks = [
+        chunk
+        async for chunk in stream_file(path=log, end_offset=10, stop=stop)
+    ]
+
+    assert chunks == []
+
+
+async def test_idle_stream_stops_when_stop_set(tmp_path: Path) -> None:
+    """An idle tail (no new content) ends promptly once stop is set.
+
+    This is the regression guard: before the cooperative stop the loop
+    parked in a fixed sleep and only a forced cancellation could end it.
+    """
+    log = tmp_path / 'log.txt'
+    log.write_text('')
+    stop = asyncio.Event()
+
+    async def drain() -> list[str]:
+        return [
+            chunk
+            async for chunk in stream_file(path=log, end_offset=0, stop=stop)
+        ]
+
+    task = asyncio.create_task(drain())
+    await asyncio.sleep(0.05)
+    stop.set()
+
+    chunks = await asyncio.wait_for(task, timeout=1.0)
+    assert chunks == []
+
+
+async def test_new_content_then_stop(tmp_path: Path) -> None:
+    """New content appended while idling is streamed before stopping."""
+    log = tmp_path / 'log.txt'
+    log.write_text('')
+    stop = asyncio.Event()
+    chunks: asyncio.Queue[str] = asyncio.Queue()
+
+    async def drain() -> None:
+        async for chunk in stream_file(path=log, end_offset=0, stop=stop):
+            await chunks.put(chunk)
+
+    task = asyncio.create_task(drain())
+    await asyncio.sleep(0.05)
+    with log.open('a') as f:
+        f.write('appended')
+
+    received = await asyncio.wait_for(chunks.get(), timeout=2.0)
+    stop.set()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert received == 'appended'

--- a/eventum/api/utils/tests/test_log_streaming.py
+++ b/eventum/api/utils/tests/test_log_streaming.py
@@ -1,0 +1,177 @@
+"""Tests for streaming a log file to a WebSocket."""
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from fastapi import WebSocket, WebSocketDisconnect, status
+from fastapi.exceptions import WebSocketException
+
+from eventum.api.utils.log_streaming import (
+    _watch_disconnect,
+    stream_log_file_to_websocket,
+)
+
+
+class _FakeWebSocket:
+    """Minimal WebSocket fake driving the streaming helper.
+
+    ``receive`` yields any ``pre_messages`` first, then a disconnect
+    dict (Starlette semantics) after ``disconnect_after`` seconds.
+    ``send_text`` records chunks, or raises ``send_error`` if set.
+    """
+
+    def __init__(
+        self,
+        *,
+        disconnect_after: float,
+        send_error: Exception | None = None,
+        state: str = 'CONNECTED',
+        pre_messages: tuple[dict[str, Any], ...] = (),
+    ) -> None:
+        self.sent: list[str] = []
+        self._disconnect_after = disconnect_after
+        self._send_error = send_error
+        self.client_state = SimpleNamespace(name=state)
+        self._pre = list(pre_messages)
+
+    async def receive(self) -> dict[str, Any]:
+        if self._pre:
+            return self._pre.pop(0)
+        await asyncio.sleep(self._disconnect_after)
+        self.client_state = SimpleNamespace(name='DISCONNECTED')
+        return {'type': 'websocket.disconnect', 'code': 1012}
+
+    async def send_text(self, data: str) -> None:
+        if self._send_error is not None:
+            raise self._send_error
+        self.sent.append(data)
+
+
+async def test_stops_when_disconnected_while_idle(tmp_path: Path) -> None:
+    """An idle stream ends promptly once the peer disconnects.
+
+    Regression guard: the disconnect arrives between reads, so it is
+    seen only because a concurrent receive watches for it.
+    """
+    log = tmp_path / 'log.txt'
+    log.write_text('')
+    ws = _FakeWebSocket(disconnect_after=0.1)
+
+    await asyncio.wait_for(
+        stream_log_file_to_websocket(
+            websocket=cast('WebSocket', ws), path=log, end_offset=0
+        ),
+        timeout=1.0,
+    )
+
+    assert ws.sent == []
+
+
+async def test_forwards_content_then_stops(tmp_path: Path) -> None:
+    """Existing tail content is forwarded before the disconnect."""
+    log = tmp_path / 'log.txt'
+    log.write_text('hello world')
+    ws = _FakeWebSocket(disconnect_after=0.2)
+
+    await asyncio.wait_for(
+        stream_log_file_to_websocket(
+            websocket=cast('WebSocket', ws), path=log, end_offset=5
+        ),
+        timeout=1.0,
+    )
+
+    assert ''.join(ws.sent) == 'world'
+
+
+async def test_send_disconnect_breaks_cleanly(tmp_path: Path) -> None:
+    """A disconnect surfaced on send ends the stream without error."""
+    log = tmp_path / 'log.txt'
+    log.write_text('hello world')
+    ws = _FakeWebSocket(
+        disconnect_after=10.0, send_error=WebSocketDisconnect(1006)
+    )
+
+    await asyncio.wait_for(
+        stream_log_file_to_websocket(
+            websocket=cast('WebSocket', ws), path=log, end_offset=5
+        ),
+        timeout=1.0,
+    )
+
+    assert ws.sent == []
+
+
+async def test_send_runtime_error_breaks_cleanly(tmp_path: Path) -> None:
+    """A post-close send RuntimeError ends the stream without error.
+
+    On shutdown the watcher's disconnect can race ahead of an in-flight
+    send, making the ASGI server raise a bare RuntimeError; the helper
+    must treat it as a disconnect, not re-raise it.
+    """
+    log = tmp_path / 'log.txt'
+    log.write_text('hello world')
+    ws = _FakeWebSocket(
+        disconnect_after=10.0,
+        send_error=RuntimeError('Unexpected ASGI message'),
+    )
+
+    await asyncio.wait_for(
+        stream_log_file_to_websocket(
+            websocket=cast('WebSocket', ws), path=log, end_offset=5
+        ),
+        timeout=1.0,
+    )
+
+    assert ws.sent == []
+
+
+async def test_watcher_ignores_non_disconnect_messages() -> None:
+    """The watcher waits for a disconnect, ignoring other messages."""
+    stop = asyncio.Event()
+    ws = _FakeWebSocket(
+        disconnect_after=0.3,
+        pre_messages=({'type': 'websocket.receive', 'text': 'ping'},),
+    )
+
+    task = asyncio.create_task(_watch_disconnect(cast('WebSocket', ws), stop))
+    await asyncio.sleep(0.05)
+    assert not stop.is_set()
+
+    await asyncio.wait_for(task, timeout=1.0)
+    assert stop.is_set()
+
+
+async def test_os_error_raises_ws_exception_when_connected(
+    tmp_path: Path,
+) -> None:
+    """An unreadable file raises a WS error while still connected."""
+    missing = tmp_path / 'does-not-exist.txt'
+    ws = _FakeWebSocket(disconnect_after=10.0)
+
+    with pytest.raises(WebSocketException) as exc:
+        await asyncio.wait_for(
+            stream_log_file_to_websocket(
+                websocket=cast('WebSocket', ws), path=missing, end_offset=0
+            ),
+            timeout=1.0,
+        )
+
+    assert exc.value.code == status.WS_1011_INTERNAL_ERROR
+
+
+async def test_os_error_swallowed_when_disconnected(tmp_path: Path) -> None:
+    """A read failure after the peer left is swallowed, not raised."""
+    missing = tmp_path / 'does-not-exist.txt'
+    ws = _FakeWebSocket(disconnect_after=10.0, state='DISCONNECTED')
+
+    await asyncio.wait_for(
+        stream_log_file_to_websocket(
+            websocket=cast('WebSocket', ws), path=missing, end_offset=0
+        ),
+        timeout=1.0,
+    )
+
+    assert ws.sent == []

--- a/eventum/app/main.py
+++ b/eventum/app/main.py
@@ -272,6 +272,11 @@ class App:
 
         """
         from eventum.server.main import build_server_app
+        from eventum.server.shutdown import reset_sse_drain
+
+        # Clear any sticky shutdown flag left by a previous in-process
+        # run (e.g. a SIGHUP restart) so fresh SSE streams stay open.
+        reset_sse_drain()
 
         server_app = build_server_app(
             enabled_services={
@@ -356,12 +361,19 @@ class App:
     def _stop_server(self) -> None:
         """Stop application server.
 
-        Requests graceful shutdown. If the server does not stop within
-        the timeout window, forces exit so long-lived connections (e.g.
-        streaming WebSockets) cannot block termination indefinitely.
+        Signals SSE streams to drain and requests graceful shutdown. If
+        the server does not stop within the timeout window, forces exit
+        so long-lived connections cannot block termination indefinitely.
         """
         if self._server is None:
             return
+
+        from eventum.server.shutdown import request_sse_drain
+
+        # Drain MCP SSE streams up front: uvicorn waits for connections
+        # before running lifespan shutdown, so without this an open SSE
+        # stream blocks until the graceful-shutdown timeout expires.
+        request_sse_drain()
 
         self._server.should_exit = True
 

--- a/eventum/app/tests/test_main.py
+++ b/eventum/app/tests/test_main.py
@@ -1,10 +1,12 @@
 """Tests for App."""
 
 import socket
+from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from sse_starlette.sse import AppStatus
 
 from eventum.app.hooks import InstanceHooks
 from eventum.app.main import App, AppError
@@ -72,6 +74,16 @@ def instance_hooks(settings: Settings) -> InstanceHooks:
 def app(settings: Settings, instance_hooks: InstanceHooks) -> App:
     """Build an App instance for tests."""
     return App(settings=settings, instance_hooks=instance_hooks)
+
+
+@pytest.fixture(autouse=True)
+def _restore_sse_drain_flag() -> Iterator[None]:
+    """Keep the SSE drain flag from leaking between tests."""
+    original = AppStatus.should_exit
+    try:
+        yield
+    finally:
+        AppStatus.should_exit = original
 
 
 def test_start_starts_server_when_only_mcp_enabled(tmp_path: Path) -> None:
@@ -273,3 +285,35 @@ def test_run_server_no_terminate_on_graceful_stop(
     app._run_server()  # noqa: SLF001
 
     terminate.assert_not_called()
+
+
+def test_stop_server_requests_sse_drain(app: App) -> None:
+    """Stopping the server signals SSE streams to drain."""
+    server = MagicMock()
+    server.should_exit = False
+    thread = MagicMock()
+    thread.is_alive.side_effect = [True, False]
+
+    app._server = server  # noqa: SLF001
+    app._server_thread = thread  # noqa: SLF001
+    AppStatus.should_exit = False
+
+    app._stop_server()  # noqa: SLF001
+
+    assert AppStatus.should_exit is True
+
+
+def test_start_server_resets_sse_drain(tmp_path: Path) -> None:
+    """Starting the server clears a sticky drain flag."""
+    app = _make_mcp_only_app(tmp_path)
+    AppStatus.should_exit = True
+
+    with (
+        patch('eventum.server.main.build_server_app'),
+        patch('eventum.app.main.uvicorn'),
+    ):
+        app.start()
+        try:
+            assert AppStatus.should_exit is False
+        finally:
+            app.stop()

--- a/eventum/server/shutdown.py
+++ b/eventum/server/shutdown.py
@@ -1,0 +1,39 @@
+"""Server-side shutdown helpers for long-lived SSE streams.
+
+SSE streams served by the MCP transport (via ``sse_starlette``) drain on
+shutdown only once the library observes the server stopping. Eventum
+runs uvicorn in a background thread, where uvicorn installs no signal
+handlers, so ``sse_starlette``'s automatic detection never fires. The
+app therefore drives the library's shutdown flag explicitly around the
+server lifecycle.
+"""
+
+
+def request_sse_drain() -> None:
+    """Signal active SSE streams to drain before the server stops.
+
+    Without this an open MCP SSE stream keeps the connection alive until
+    uvicorn's graceful-shutdown timeout expires and tasks are force
+    cancelled.
+    """
+    _set_sse_should_exit(value=True)
+
+
+def reset_sse_drain() -> None:
+    """Clear the SSE drain flag before (re)starting the server.
+
+    The flag is a process-global in ``sse_starlette``; an in-process
+    restart (SIGHUP) reuses it, so it must be cleared on start or the
+    fresh server would close every SSE stream immediately.
+    """
+    _set_sse_should_exit(value=False)
+
+
+def _set_sse_should_exit(*, value: bool) -> None:
+    """Set ``sse_starlette``'s shutdown flag if it is installed."""
+    try:
+        from sse_starlette.sse import AppStatus
+    except ImportError:
+        return
+
+    AppStatus.should_exit = value

--- a/eventum/server/tests/test_shutdown.py
+++ b/eventum/server/tests/test_shutdown.py
@@ -1,0 +1,32 @@
+"""Tests for server shutdown helpers."""
+
+from collections.abc import Iterator
+
+import pytest
+from sse_starlette.sse import AppStatus
+
+from eventum.server.shutdown import request_sse_drain, reset_sse_drain
+
+
+@pytest.fixture(autouse=True)
+def _restore_sse_flag() -> Iterator[None]:
+    """Restore the process-global SSE flag around each test."""
+    original = AppStatus.should_exit
+    try:
+        yield
+    finally:
+        AppStatus.should_exit = original
+
+
+def test_request_sse_drain_sets_flag() -> None:
+    """Requesting drain flips the sse_starlette shutdown flag on."""
+    AppStatus.should_exit = False
+    request_sse_drain()
+    assert AppStatus.should_exit is True
+
+
+def test_reset_sse_drain_clears_flag() -> None:
+    """Resetting clears the flag so a restart keeps streaming."""
+    AppStatus.should_exit = True
+    reset_sse_drain()
+    assert AppStatus.should_exit is False

--- a/eventum/server/tests/test_sse_drain.py
+++ b/eventum/server/tests/test_sse_drain.py
@@ -1,0 +1,116 @@
+"""An active SSE stream drains on graceful shutdown.
+
+Boots a real ``sse_starlette`` EventSourceResponse under uvicorn in a
+background thread (App's model) and holds the stream open from a client
+thread. ``request_sse_drain()`` must let the server stop well within the
+graceful window instead of blocking until it expires - the MCP SSE drain
+path the flag-flip unit tests cannot exercise.
+"""
+
+import asyncio
+import contextlib
+import socket
+import threading
+import time
+from collections.abc import AsyncIterator, Iterator
+
+import httpx
+import pytest
+import uvicorn
+from fastapi import FastAPI
+from sse_starlette.sse import AppStatus, EventSourceResponse
+
+from eventum.server.shutdown import request_sse_drain, reset_sse_drain
+
+_GRACEFUL_TIMEOUT = 10
+_STARTUP_TIMEOUT = 20.0
+_POLL = 0.05
+
+
+@pytest.fixture(autouse=True)
+def _restore_sse_flag() -> Iterator[None]:
+    """Restore the process-global SSE flag around the test."""
+    original = AppStatus.should_exit
+    try:
+        yield
+    finally:
+        AppStatus.should_exit = original
+
+
+def _free_port() -> int:
+    sock = socket.socket()
+    sock.bind(('127.0.0.1', 0))
+    port = int(sock.getsockname()[1])
+    sock.close()
+    return port
+
+
+def test_active_sse_stream_drains_on_shutdown() -> None:
+    """A held-open SSE stream must not block the graceful window."""
+    app = FastAPI()
+
+    @app.get('/sse')
+    async def sse() -> EventSourceResponse:
+        async def gen() -> AsyncIterator[dict[str, str]]:
+            while True:
+                yield {'data': 'tick'}
+                await asyncio.sleep(0.1)
+
+        return EventSourceResponse(gen())
+
+    port = _free_port()
+    reset_sse_drain()
+    server = uvicorn.Server(
+        uvicorn.Config(
+            app,
+            host='127.0.0.1',
+            port=port,
+            log_level='warning',
+            lifespan='on',
+            timeout_graceful_shutdown=_GRACEFUL_TIMEOUT,
+        ),
+    )
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    start = time.monotonic()
+    while not server.started:
+        if time.monotonic() - start > _STARTUP_TIMEOUT:
+            server.should_exit = True
+            pytest.fail('server did not start in time')
+        time.sleep(_POLL)
+
+    connected = threading.Event()
+
+    def hold() -> None:
+        # The server closing the SSE on shutdown surfaces as a read error
+        # in the client; that is the expected end of a drained stream.
+        with (
+            contextlib.suppress(httpx.HTTPError),
+            httpx.Client() as client,
+            client.stream(
+                'GET',
+                f'http://127.0.0.1:{port}/sse',
+                timeout=_STARTUP_TIMEOUT,
+            ) as resp,
+        ):
+            for _ in resp.iter_lines():
+                connected.set()
+
+    client_thread = threading.Thread(target=hold, daemon=True)
+    client_thread.start()
+    if not connected.wait(timeout=_STARTUP_TIMEOUT):
+        server.should_exit = True
+        pytest.fail('SSE stream did not connect')
+
+    # Mirror App._stop_server: drain SSE streams, then request shutdown.
+    request_sse_drain()
+    server.should_exit = True
+
+    shutdown_start = time.monotonic()
+    thread.join(timeout=_GRACEFUL_TIMEOUT - 2)
+    elapsed = time.monotonic() - shutdown_start
+
+    assert not thread.is_alive(), 'server hung on shutdown with active SSE'
+    assert elapsed < _GRACEFUL_TIMEOUT - 3
+    client_thread.join(timeout=2.0)


### PR DESCRIPTION
## Problem

Stopping the app with `Ctrl+C` hung for the full graceful-shutdown timeout (~10s) and printed `CancelledError` tracebacks whenever a log-stream WebSocket (the Studio log tab) or an MCP SSE client stayed connected.

**Root cause:** uvicorn waits for active connections to close *before* running lifespan shutdown, bounded by `timeout_graceful_shutdown`. Two long-lived streams never closed during that window:

- The log-tail **WebSockets** (`/{id}/logs`, `/logs/main`) ran `stream_file` in an infinite loop parked in `asyncio.sleep`, noticing a disconnect only on the next send — so an idle stream was force-cancelled mid-read at the timeout.
- The **MCP Streamable-HTTP SSE** stream relies on `sse_starlette`'s shutdown detection, which never fires because Eventum runs uvicorn on a background thread (no signal handlers installed there).

uvicorn then force-cancelled the tasks (the tracebacks), and that `force_exit` also skipped `lifespan.shutdown()` (a third lifespan `CancelledError`).

## Changes

- **WS (cooperative stop):** `stream_file` takes a `stop` event with an interruptible idle wait; a new shared helper `api/utils/log_streaming.stream_log_file_to_websocket` runs a concurrent watcher on `websocket.receive()` that sets `stop` on disconnect. Both log routers use it. An idle stream now closes at once on client disconnect or server shutdown, and the file closes via the normal path (no traceback). A post-close send `RuntimeError` (shutdown race) is treated as a disconnect.
- **SSE (explicit drain):** new `server/shutdown.py` exposes `request_sse_drain()`/`reset_sse_drain()` over `sse_starlette`'s `AppStatus.should_exit`. `App._stop_server` drains before requesting shutdown; `App._start_server` clears the flag on start (it is a process-global; an in-process SIGHUP restart would otherwise self-close fresh SSE streams).

## Verification

- `pytest` **318 passed** across `api`/`app`/`server` (+11 new tests); `ruff` clean; `mypy` clean (426 files).
- End-to-end under a real uvicorn-in-a-thread (App's model) holding an idle WS **and** a standing SSE stream, then `SIGINT`: server stops in **~0.6s with no tracebacks**. A control without the SSE drain reproduces the original **~10.4s hang + `CancelledError`**, confirming the regression guard.
- Reviewed via an adversarial multi-agent pass; all actionable findings addressed (added the SSE-drain regression test, hardened a timing-fragile test, covered the watcher predicate and OSError branches).

## Note (out of scope)

`eventum/api/routers/docs/static/asyncapi.yml` is stale on `develop` (`version: 2.5.0`); `build_api_app()` regenerates it to `2.6.0` on start. Left out of this PR — a housekeeping item for the release process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
