### PR TITLE
docs: remove utils repository from the repositories list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,6 @@ Eventum is developed across several repositories in the [eventum-generator](http
 | [website](https://github.com/eventum-generator/website) | Project website source |
 | [content-packs](https://github.com/eventum-generator/content-packs) | Ready-to-use generators for SIEM data sources (ECS-compatible) |
 | [dependency-patterns](https://github.com/eventum-generator/dependency-patterns) | Collection of data dependency patterns with validation queries |
-| [utils](https://github.com/eventum-generator/utils) | Helper utilities for Eventum |
 
 ## Questions and discussions
 


### PR DESCRIPTION
Removes the utils repository from the Project repositories table in CONTRIBUTING.md - it is an outdated artifact (a 2024 systemd script for the old eventum-studio) and is being deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)