### PR TITLE
fix(ui): clear per-project query cache on config delete and create

### DIFF
--- a/eventum/ui/src/api/hooks/useGeneratorConfigs.ts
+++ b/eventum/ui/src/api/hooks/useGeneratorConfigs.ts
@@ -1,4 +1,5 @@
 import {
+  QueryClient,
   UseQueryResult,
   useMutation,
   useQuery,
@@ -30,11 +31,23 @@ const GENERATOR_CONFIG_DIRS_QUERY_KEY = ['generator-config-dirs'];
 const GENERATOR_CONFIG_DIRS_EXTENDED_QUERY_KEY = [
   'generator-config-dirs-extended',
 ];
+const GENERATOR_CONFIG_DIR_FILES_QUERY_KEY = ['generator-config-dir-files'];
 
 const GENERATOR_CONFIG_DIRS_COMMON_QUERY_KEYS = [
   GENERATOR_CONFIG_DIRS_QUERY_KEY,
   GENERATOR_CONFIG_DIRS_EXTENDED_QUERY_KEY,
 ];
+
+// Per-project config and file-tree caches are keyed by name and outlive
+// the project; drop them so a new project reusing the name starts clean.
+function dropProjectQueries(queryClient: QueryClient, name: string) {
+  queryClient.removeQueries({
+    queryKey: [...GENERATOR_CONFIG_DIRS_QUERY_KEY, name],
+  });
+  queryClient.removeQueries({
+    queryKey: [...GENERATOR_CONFIG_DIR_FILES_QUERY_KEY, name],
+  });
+}
 
 export function useGeneratorDirs(
   extended: false
@@ -72,7 +85,9 @@ export function useCreateGeneratorConfigMutation() {
   return useMutation({
     mutationFn: ({ name, config }: { name: string; config: GeneratorConfig }) =>
       createGeneratorConfig(name, config),
-    onSuccess: async () => {
+    onSuccess: async (_, { name }) => {
+      dropProjectQueries(queryClient, name);
+
       await Promise.all(
         GENERATOR_CONFIG_DIRS_COMMON_QUERY_KEYS.map((key) =>
           queryClient.invalidateQueries({ queryKey: key, exact: true })
@@ -102,7 +117,9 @@ export function useDeleteGeneratorConfigMutation() {
 
   return useMutation({
     mutationFn: ({ name }: { name: string }) => deleteGeneratorConfig(name),
-    onSuccess: async () => {
+    onSuccess: async (_, { name }) => {
+      dropProjectQueries(queryClient, name);
+
       await Promise.all(
         GENERATOR_CONFIG_DIRS_COMMON_QUERY_KEYS.map((key) =>
           queryClient.invalidateQueries({ queryKey: key, exact: true })
@@ -117,8 +134,6 @@ export function useGeneratorConfigPathMutation() {
     mutationFn: ({ name }: { name: string }) => getGeneratorConfigPath(name),
   });
 }
-
-const GENERATOR_CONFIG_DIR_FILES_QUERY_KEY = ['generator-config-dir-files'];
 
 export function useGeneratorFileTree(name: string) {
   return useQuery({


### PR DESCRIPTION
## Problem

Deleting a generator project and creating a new one with the same name showed the **old project's plugin settings** in the form.

## Cause

`useDeleteGeneratorConfigMutation` and `useCreateGeneratorConfigMutation` invalidated only the directory-list query keys with `exact: true`. The per-project caches keyed by name — `['generator-config-dirs', name]` (the config that seeds the project form) and `['generator-config-dir-files', name]` (file tree) — were never evicted, so they outlived the project. A new project reusing the name then read the stale cached config.

## Fix

Drop those per-project query subtrees with `removeQueries` on both delete and create, so a reused name always starts from a clean cache. `removeQueries` rather than `invalidateQueries` because the project is gone (delete) or freshly written (create) — refetching the old key is pointless.

## Testing

- `eslint`, `prettier --check`, `tsc --noEmit` pass on the change.
- No automated test added: the `ui` package has no test runner yet (no vitest/jest, no test files). Can set one up separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
