### PR TITLE
Remove interactive tutorial image from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,6 @@ Eventum produces synthetic events and delivers them anywhere — in real time or
 </p>
 
 <p align="center">
-  <a href="https://app.arcade.software/share/QjQVk47rN7AJd5Eft38x">
-    <img src="https://raw.githubusercontent.com/eventum-generator/eventum/master/.github/assets/arcade-tutorial.png" alt="Interactive tutorial — build your first generator" width="700" />
-  </a>
-</p>
-
-<p align="center">
   <a href="https://app.arcade.software/share/QjQVk47rN7AJd5Eft38x"><strong>▶ Launch the interactive tutorial</strong></a>
 </p>
 


### PR DESCRIPTION
Removed the interactive tutorial image link from the README.

## Summary

<!-- What does this change do, and why? -->

## Related issue

<!-- e.g. Closes #123. Use "Closes" so the issue auto-closes on merge. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor or internal change
- [ ] Documentation
- [x] Other

## Checklist

- [ ] Branched off `develop` and targeting `develop`.
- [ ] Tests added or updated, co-located under `<package>/tests/`.
- [ ] `uv run ruff format` and `uv run ruff check` pass.
- [ ] `uv run mypy eventum/` passes.
- [ ] `uv run pytest` passes.
- [ ] For UI changes: `pnpm lint` and `pnpm build` pass.
- [ ] Commit messages follow Conventional Commits with a valid package scope.
- [ ] Documentation updated if behavior changed.
