### PR TITLE
fix(ui): expose MCP settings in Studio Settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### 🐛 Bug Fixes
 
 - **Recreating a deleted project no longer shows the old project's settings** — creating a project with the same name as a deleted one now starts from a clean configuration; previously its plugin tabs could still display the deleted project's settings
+- **MCP settings are now editable in the Studio Settings page** — the Server parameters section gained MCP controls (enable the HTTP server, allow write tools, mount path, allowed hosts); previously these were configurable only by editing `eventum.yml`, and saving settings from Studio silently reset any existing MCP configuration to defaults
 
 ## 2.6.0 (2026-06-11)
 

--- a/eventum/api/tests/test_instance.py
+++ b/eventum/api/tests/test_instance.py
@@ -1,8 +1,9 @@
 """Tests for instance API router."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
+import yaml
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -17,7 +18,7 @@ from eventum.app.models.settings import Settings
 from eventum.core.parameters import GenerationParameters
 
 
-@pytest.fixture()
+@pytest.fixture
 def tmp_settings(tmp_path):
     return Settings(
         server=ServerParameters(
@@ -34,7 +35,7 @@ def tmp_settings(tmp_path):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def hooks(tmp_path):
     return {
         'get_settings_file_path': lambda: tmp_path / 'settings.yml',
@@ -43,7 +44,7 @@ def hooks(tmp_path):
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def client(tmp_settings, hooks):
     app = FastAPI()
     app.state.settings = tmp_settings
@@ -87,6 +88,27 @@ def test_update_settings(client, tmp_settings, tmp_path):
     assert response.status_code == 200
     settings_file = tmp_path / 'settings.yml'
     assert settings_file.exists()
+
+
+def test_update_settings_preserves_mcp(client, tmp_settings, tmp_path):
+    new_settings = tmp_settings.model_dump(mode='json')
+    new_settings['server']['mcp'] = {
+        'enabled': True,
+        'allow_write': True,
+        'path': '/custom-mcp',
+        'allowed_hosts': ['eventum.example'],
+    }
+    response = client.put('/instance/settings', json=new_settings)
+    assert response.status_code == 200
+
+    settings_file = tmp_path / 'settings.yml'
+    written = yaml.safe_load(settings_file.read_text())
+    assert written['server']['mcp'] == {
+        'enabled': True,
+        'allow_write': True,
+        'path': '/custom-mcp',
+        'allowed_hosts': ['eventum.example'],
+    }
 
 
 def test_update_settings_hook_error(client, hooks, tmp_settings):

--- a/eventum/ui/src/api/routes/instance/schemas.ts
+++ b/eventum/ui/src/api/routes/instance/schemas.ts
@@ -51,6 +51,24 @@ export const AuthParametersSchema = z.object({
   password: z.preprocess(emptyToUndefined, z.string().min(1).optional()),
 });
 
+export const MCPParametersSchema = z.object({
+  enabled: z.boolean().optional(),
+  allow_write: z.boolean().optional(),
+  path: z.preprocess(
+    emptyToUndefined,
+    z
+      .string()
+      .min(1)
+      .refine((v) => v.startsWith('/'), 'Path must start with "/"')
+      .refine(
+        (v) => v.length === 1 || !v.endsWith('/'),
+        'Path must not end with "/"'
+      )
+      .optional()
+  ),
+  allowed_hosts: z.array(z.string()).optional(),
+});
+
 export const ServerParametersSchema = z.object({
   ui_enabled: z.boolean().optional(),
   api_enabled: z.boolean().optional(),
@@ -61,6 +79,7 @@ export const ServerParametersSchema = z.object({
   ),
   ssl: SSLParametersSchema.optional(),
   auth: AuthParametersSchema.optional(),
+  mcp: MCPParametersSchema.optional(),
 });
 export type ServerParameters = z.infer<typeof ServerParametersSchema>;
 

--- a/eventum/ui/src/pages/SettingsPage/ServerParametersSection/index.tsx
+++ b/eventum/ui/src/pages/SettingsPage/ServerParametersSection/index.tsx
@@ -7,6 +7,7 @@ import {
   Radio,
   Stack,
   Switch,
+  TagsInput,
   Text,
   TextInput,
   Tooltip,
@@ -281,6 +282,69 @@ export const ServerParametersSection: FC<ServerParametersSectionProps> = ({
         Username and password are parameters in configuration file that stored
         in <b>plain text</b>.
       </Alert>
+
+      <Text size="sm" fw="bold" mt="md">
+        MCP
+      </Text>
+      <Group>
+        <Switch
+          label={
+            <LabelWithTooltip
+              label="Enable MCP server"
+              tooltip="Mount the MCP server over HTTP so connected agents can manage Eventum"
+            />
+          }
+          {...form.getInputProps('mcp.enabled', { type: 'checkbox' })}
+          key={form.key('mcp.enabled')}
+        />
+        <Switch
+          label={
+            <LabelWithTooltip
+              label="Allow write tools"
+              tooltip="Permit MCP write tools over HTTP. A connected agent can write and preview generators, and some plugins execute code on the host"
+            />
+          }
+          disabled={!form.getValues().mcp?.enabled}
+          {...form.getInputProps('mcp.allow_write', { type: 'checkbox' })}
+          key={form.key('mcp.allow_write')}
+        />
+      </Group>
+      <Alert
+        variant="default"
+        icon={<Box c="orange" component={IconAlertTriangle} />}
+        title="Write tools enabled"
+        hidden={!form.getValues().mcp?.allow_write}
+      >
+        A connected agent can write and preview generators, and some plugins
+        execute code on the host. Enable only on trusted networks with trusted
+        agents.
+      </Alert>
+      <TextInput
+        label={
+          <LabelWithTooltip
+            label="Mount path"
+            tooltip="Mount path for the MCP HTTP endpoint"
+          />
+        }
+        placeholder="/mcp"
+        disabled={!form.getValues().mcp?.enabled}
+        {...form.getInputProps('mcp.path')}
+        key={form.key('mcp.path')}
+      />
+      <TagsInput
+        label={
+          <LabelWithTooltip
+            label="Allowed hosts"
+            tooltip="Allowed Host header values for DNS-rebinding protection. Leave empty to disable the check (suitable behind a trusted reverse proxy)"
+          />
+        }
+        placeholder="Press Enter to submit a host"
+        disabled={!form.getValues().mcp?.enabled}
+        {...form.getInputProps('mcp.allowed_hosts')}
+        value={form.getValues().mcp?.allowed_hosts ?? []}
+        onChange={(value) => form.setFieldValue('mcp.allowed_hosts', value)}
+        key={form.key('mcp.allowed_hosts')}
+      />
     </Stack>
   );
 };


### PR DESCRIPTION
## Summary

Fixes #156 — MCP settings were missing from the Studio Settings page; they could only be configured by editing `eventum.yml`.

Root cause was frontend-only: the Zod `ServerParametersSchema` lacked the `mcp` field, so it was stripped when validating the settings response and never reached the form. As a side effect, since the settings `PUT` persists with `model_dump(exclude_unset=True)`, **saving settings from Studio silently reset any existing MCP config to defaults** (the UI never sent `mcp` back).

## Changes

- **`instance/schemas.ts`** — add `MCPParametersSchema` (enabled, allow_write, path with the backend path-validator mirrored, allowed_hosts) and wire `mcp` into `ServerParametersSchema`.
- **`ServerParametersSection/index.tsx`** — add an MCP subsection to Server parameters: enable / allow-write switches (grouped), a just-in-time warning alert when write tools are on, mount path, and an allowed-hosts tags input. Sub-fields gate on `mcp.enabled`; the enable toggle is independent since the server runs whenever `api_enabled OR ui_enabled OR mcp.enabled`.
- **`test_instance.py`** — regression test asserting MCP values survive the settings `PUT` round-trip.
- **`CHANGELOG.md`** — Unreleased bug-fix entry.

## Verification

`ruff check` · `ruff format --check` · `mypy` (419 files) · `pytest` (1266 passed) · `pnpm build` · `eslint` · `prettier` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)