### PR TITLE
fix(api): run scenario globals-usage scan in a worker thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### 🐛 Bug Fixes
 
 - **Recreating a deleted project no longer shows the old project's settings** — creating a project with the same name as a deleted one now starts from a clean configuration; previously its plugin tabs could still display the deleted project's settings
+- **Opening a scenario with many instances no longer times out** — scenarios with several generators now open reliably; previously the page could hang and fail after about ten seconds while loading each instance's global-state usage
 
 ## 2.6.0 (2026-06-11)
 

--- a/eventum/api/routers/scenarios/routes.py
+++ b/eventum/api/routers/scenarios/routes.py
@@ -9,7 +9,6 @@ import structlog
 import yaml
 from fastapi import APIRouter, Body, HTTPException, status
 from fastapi import Path as FastApiPath
-from jinja2 import TemplateSyntaxError
 
 from eventum.api.dependencies.app import SettingsDep
 from eventum.api.routers.generator_configs.globals_detector import (
@@ -31,12 +30,53 @@ from eventum.api.routers.startup.dependencies import (
     get_startup_generator_parameters_list,
 )
 from eventum.api.utils.response_description import merge_responses
+from eventum.app.workspace import WorkspaceError, resolve_generator_dir
 from eventum.plugins.event.plugins.template.plugin import TemplateEventPlugin
 from eventum.utils.json_utils import normalize_types
 
 logger = structlog.stdlib.get_logger()
 
 router = APIRouter()
+
+_TEMPLATE_SUFFIXES = ('.j2', '.jinja')
+
+
+def _collect_globals_usage(generator_dir: Path) -> GlobalsUsage:
+    """Scan a generator directory for Jinja2 templates and detect
+    globals usage across all of them.
+
+    Walks the directory tree once, reads each template, and runs AST
+    detection. Performs blocking filesystem IO and CPU-bound parsing,
+    so it must run in a worker thread to avoid blocking the event
+    loop.
+
+    Parameters
+    ----------
+    generator_dir : Path
+        Resolved generator directory to scan.
+
+    Returns
+    -------
+    GlobalsUsage
+        Merged writes, reads, and warnings from all templates.
+
+    """
+    usage = GlobalsUsage()
+
+    for filepath in generator_dir.rglob('*'):
+        if filepath.suffix not in _TEMPLATE_SUFFIXES or not filepath.is_file():
+            continue
+
+        rel_path = str(filepath.relative_to(generator_dir))
+        try:
+            source = filepath.read_text(encoding='utf-8')
+        except OSError:
+            logger.warning('Failed to read template file', path=str(filepath))
+            continue
+
+        usage.merge(detect_globals_usage(source, rel_path))
+
+    return usage
 
 
 @router.get(
@@ -266,42 +306,25 @@ async def get_generator_globals_usage(
     ],
     settings: SettingsDep,
 ) -> GlobalsUsageResponse:
-    generator_dir = (settings.path.generators_dir / generator_name).resolve()
-
-    if not generator_dir.is_relative_to(settings.path.generators_dir):
+    try:
+        generator_dir = resolve_generator_dir(
+            settings.path.generators_dir, generator_name
+        )
+    except WorkspaceError:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=(
                 'Accessing directories outside generators_dir is not allowed'
             ),
-        )
+        ) from None
 
     if not generator_dir.is_dir():
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f'Generator configuration not found: {generator_name}',
         )
-    usage = GlobalsUsage()
 
-    template_files: list[tuple[Path, str]] = []
-    for pattern in ('**/*.j2', '**/*.jinja'):
-        for filepath in generator_dir.glob(pattern):
-            if filepath.is_file():
-                rel_path = str(filepath.relative_to(generator_dir))
-                template_files.append((filepath, rel_path))
-
-    for filepath, rel_path in template_files:
-        try:
-            async with aiofiles.open(filepath, encoding='utf-8') as f:
-                source = await f.read()
-            template_usage = await asyncio.to_thread(
-                detect_globals_usage, source, rel_path
-            )
-            usage.merge(template_usage)
-        except OSError:
-            logger.warning('Failed to read template file', path=str(filepath))
-        except TemplateSyntaxError:
-            logger.warning('Failed to parse template file', path=str(filepath))
+    usage = await asyncio.to_thread(_collect_globals_usage, generator_dir)
 
     return GlobalsUsageResponse(
         writes=[

--- a/eventum/api/routers/scenarios/tests/test_routes.py
+++ b/eventum/api/routers/scenarios/tests/test_routes.py
@@ -1,0 +1,136 @@
+"""Tests for scenarios router helpers and endpoints."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from eventum.api.routers.scenarios import router
+from eventum.api.routers.scenarios.routes import _collect_globals_usage
+from eventum.app.models.parameters.log import LogParameters
+from eventum.app.models.parameters.path import PathParameters
+from eventum.app.models.parameters.server import ServerParameters
+from eventum.app.models.settings import Settings
+from eventum.core.parameters import GenerationParameters
+
+# --- _collect_globals_usage ---
+
+
+def test_collect_finds_templates_recursively(tmp_path):
+    (tmp_path / 'root.jinja').write_text('{%- do globals.set("a", 1) -%}')
+    sub = tmp_path / 'sub'
+    sub.mkdir()
+    (sub / 'nested.j2').write_text('{%- set x = globals.get("b", 0) -%}')
+
+    usage = _collect_globals_usage(tmp_path)
+
+    assert {w.key for w in usage.writes} == {'a'}
+    assert {r.key for r in usage.reads} == {'b'}
+    templates = {w.template for w in usage.writes}
+    templates |= {r.template for r in usage.reads}
+    assert templates == {'root.jinja', str(Path('sub') / 'nested.j2')}
+
+
+def test_collect_skips_non_template_files(tmp_path):
+    (tmp_path / 'data.txt').write_text('{%- do globals.set("x", 1) -%}')
+    (tmp_path / 'config.yml').write_text('{%- do globals.set("y", 1) -%}')
+
+    usage = _collect_globals_usage(tmp_path)
+
+    assert usage.writes == []
+    assert usage.reads == []
+
+
+def test_collect_empty_dir(tmp_path):
+    usage = _collect_globals_usage(tmp_path)
+
+    assert usage.writes == []
+    assert usage.reads == []
+    assert usage.warnings == []
+
+
+def test_collect_merges_warnings(tmp_path):
+    (tmp_path / 'template.j2').write_text('{%- do globals.update(data) -%}')
+
+    usage = _collect_globals_usage(tmp_path)
+
+    assert len(usage.warnings) == 1
+    assert usage.warnings[0].type == 'update_call'
+
+
+def test_collect_skips_unreadable_file(tmp_path):
+    (tmp_path / 'good.j2').write_text('{%- do globals.set("a", 1) -%}')
+    (tmp_path / 'bad.j2').write_text('{%- do globals.set("b", 1) -%}')
+
+    real_read_text = Path.read_text
+
+    def fake_read_text(self, *args, **kwargs):
+        if self.name == 'bad.j2':
+            raise OSError('boom')
+        return real_read_text(self, *args, **kwargs)
+
+    with patch.object(Path, 'read_text', fake_read_text):
+        usage = _collect_globals_usage(tmp_path)
+
+    assert {w.key for w in usage.writes} == {'a'}
+
+
+# --- GET /{name}/generators/{generator_name}/globals-usage ---
+
+
+@pytest.fixture
+def client(tmp_path):
+    settings = Settings(
+        server=ServerParameters(),
+        generation=GenerationParameters(),
+        log=LogParameters(),
+        path=PathParameters(
+            logs=tmp_path / 'logs',
+            startup=tmp_path / 'startup.yml',
+            generators_dir=tmp_path / 'generators',
+            keyring_cryptfile=tmp_path / 'keyring.cfg',
+        ),
+    )
+    settings.path.generators_dir.mkdir()
+    settings.path.startup.write_text(
+        '- id: gen-1\n'
+        '  path: gen-1/generator.yml\n'
+        '  scenarios:\n'
+        '    - myscenario\n'
+    )
+    gen_dir = settings.path.generators_dir / 'gen-1'
+    gen_dir.mkdir()
+    (gen_dir / 'event.j2').write_text('{%- do globals.set("users", x) -%}')
+
+    app = FastAPI()
+    app.state.settings = settings
+    app.include_router(router, prefix='/scenarios')
+    with TestClient(app) as c:
+        yield c
+
+
+def test_globals_usage_endpoint_returns_usage(client):
+    response = client.get(
+        '/scenarios/myscenario/generators/gen-1/globals-usage'
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert [w['key'] for w in data['writes']] == ['users']
+    assert data['reads'] == []
+
+
+def test_globals_usage_endpoint_unknown_scenario(client):
+    response = client.get('/scenarios/absent/generators/gen-1/globals-usage')
+
+    assert response.status_code == 404
+
+
+def test_globals_usage_endpoint_missing_generator(client):
+    response = client.get(
+        '/scenarios/myscenario/generators/absent/globals-usage'
+    )
+
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary

The `globals-usage` endpoint walked the generator directory and parsed templates directly on the asyncio event loop. The scenario page fires one such request per generator concurrently (`useMultiGlobalsUsage`), so the blocking traversals serialized and stalled all other API traffic; on slower filesystems (e.g. Docker bind mounts) the responses exceeded the UI's 10s axios timeout and the scenario page failed to load.

## Changes

- Move the whole directory scan (single-pass `rglob` walk + read + AST detection) into one `asyncio.to_thread` call, matching the established `get_generator_file_tree` pattern. The event loop stays free, so the per-generator requests overlap and other traffic is not blocked.
- Reuse `resolve_generator_dir` from `app.workspace` for path-safety (it also resolves the base path) instead of reimplementing the check; the domain `WorkspaceError` is translated to HTTP 403 at the boundary.
- Drop the dead `except TemplateSyntaxError` branch — `detect_globals_usage` already swallows parse errors internally.

## Tests

- Unit tests for the scan helper: recursion, non-template skip, empty dir, warnings, unreadable file.
- Route tests for the endpoint: success, unknown scenario (404), missing generator (404).

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)
