### PR TITLE
fix(mcp): widen the agent guiding surface (#154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug Fixes
 
+- **MCP agents get the fast path for large samples and a fuller picture of Eventum** — building a generator over MCP no longer pushes large CSV/JSON samples through the slow `write_generator_file` tool: the agent is guided to upload them via the REST file API (over HTTP) or write them straight to disk (when running locally). The agent is also told that event templates can import any installed Python package — not only `rand`/`faker`/`mimesis` — and run shell commands via `subprocess`, that the running server exposes a REST API with an OpenAPI schema to fall back on when no MCP tool fits, and how live/sample run modes and scenarios work
 - **Recreating a deleted project no longer shows the old project's settings** — creating a project with the same name as a deleted one now starts from a clean configuration; previously its plugin tabs could still display the deleted project's settings
 
 ## 2.6.0 (2026-06-11)

--- a/eventum/mcp/prompts/authoring.py
+++ b/eventum/mcp/prompts/authoring.py
@@ -17,12 +17,13 @@ for realistic peaks, `linspace`/`timestamps` for a fixed or past \
 range, `static` for a fixed batch at start time, `http` for \
 request-driven ticks.
    - Event (content): pick the family. `template` renders Jinja - read \
-`eventum://templating/reference` for the in-template API (samples, \
-`module.rand`/`faker`/`mimesis`, `locals`/`shared`/`globals` state, \
-`dispatch`). `replay` re-emits lines from an existing log file. \
-`script` runs an existing Python file - MCP file tools cannot write \
-`.py`, so pick it only when the script is already on disk; otherwise \
-prefer `template`.
+`eventum://templating/reference` for the in-template API: `samples`, \
+`module.<name>` (imports any installed Python package; \
+`rand`/`faker`/`mimesis` are bundled), `subprocess`, \
+`locals`/`shared`/`globals` state, and `dispatch`. `replay` re-emits \
+lines from an existing log file. `script` runs an existing Python file \
+- MCP file tools cannot write `.py`, so pick it only when the script \
+is already on disk; otherwise prefer `template`.
    - Output (delivery): `stdout`/`file` for local sinks, \
 `http`/`tcp`/`udp`/`kafka` to push to a pipeline, \
 `clickhouse`/`opensearch` to index into a datastore; pick a formatter \
@@ -38,7 +39,13 @@ drifting values. Inspect any data files with `describe_sample`.
 the generator directory: `generator.yml`, plus `templates/` and \
 `samples/` for a template generator. A `replay` generator just points \
 at its log file; a `script` generator points at an existing Python \
-file - `.py` is not writable over MCP.
+file - `.py` is not writable over MCP. For a large CSV or JSON \
+sample, do not pass it through `write_generator_file` (carrying big \
+content this way is slow): over HTTP, once the generator exists, \
+upload it with the server's REST file API (`POST \
+/api/generator-configs/{name}/file/{filepath}`, multipart field \
+`content`); running locally, write it straight into the generator's \
+`samples/` directory. Then reference it from the config.
 5. Validate with `validate_generator` and fix until it passes.
 6. Preview before finishing: `preview_timestamps` for the timing \
 shape, then `preview_events` for real rendered events. For a past \

--- a/eventum/mcp/prompts/operations.py
+++ b/eventum/mcp/prompts/operations.py
@@ -21,6 +21,19 @@ startup file.
 good, `unregister_generator` drops it from the runtime and the startup \
 file; follow with `delete_generator` if you also want its files gone.
 
+Modes. A generator runs in live mode (wall-clock synchronized \
+streaming) or sample mode (max-speed bulk generation). The mode comes \
+from the registered execution settings (`live_mode`); override it with \
+the `execution` argument of `register_generator`. For a quick bounded \
+sample without registering, use `run_generator`.
+
+Scenarios and shared state. Generators coordinate at runtime through \
+`globals` state; group related ones into named scenarios for \
+coordinated lifecycle and global-state flow. Scenarios live in the \
+`scenarios` field of the startup file (or the Studio UI); there is no \
+MCP tool for them - manage them through the REST scenarios API (see the \
+OpenAPI schema) or Studio.
+
 Write tools (register, start, stop, unregister, delete, file writes) \
 require the server to allow writes; when it does not, they fail and \
 only the read tools work.

--- a/eventum/mcp/resources/templating.py
+++ b/eventum/mcp/resources/templating.py
@@ -14,7 +14,11 @@ from eventum.plugins.event.plugins.template.reference import (
 _INTRO = (
     'The API the template plugin exposes inside Eventum event '
     'templates (Jinja) - the objects you call when authoring template '
-    'files. Signatures omit `self`.'
+    'files. Signatures omit `self`. The `module` namespace imports any '
+    'installed Python module (`module.<name>`), not only the bundled '
+    '`rand`, `faker`, and `mimesis`. Templates also enable the Jinja '
+    '`do` and `loopcontrols` extensions (`{% do %}`, `{% break %}`, '
+    '`{% continue %}`).'
 )
 
 
@@ -44,8 +48,9 @@ def register(mcp: FastMCP) -> None:
         'eventum://templating/reference',
         name='Template context reference',
         description=(
-            "The template plugin's in-template API: module.rand.*, "
-            'samples.*, dispatch, state, and the event fields. Read '
+            "The template plugin's in-template API: the `module` "
+            'importer (any Python package), module.rand.*, samples.*, '
+            'dispatch, subprocess, state, and the event fields. Read '
             'this before writing template files.'
         ),
         mime_type='text/markdown',

--- a/eventum/mcp/server.py
+++ b/eventum/mcp/server.py
@@ -38,6 +38,14 @@ _INSTRUCTIONS = (
     'user to the eventum-keyring CLI to add or read a value.'
 )
 
+_REST_API_NOTE = (
+    'This server also exposes a REST API at `/api` (OpenAPI schema at '
+    '`/api/openapi.json`, Swagger UI at `/api/swagger`) behind the same '
+    'credentials as this MCP endpoint. When an operation has no MCP '
+    'tool - for example uploading a large sample file - read that '
+    'schema and call the REST API directly.'
+)
+
 
 def build_server(
     context: AuthoringContext,
@@ -67,10 +75,14 @@ def build_server(
         workspace, validate/preview, and run tools; the
         templating-reference, generator-schema, examples, and
         workspace-configs resources; the authoring prompts; and,
-        when ``live`` is set, the live generator-management tools.
+        when ``live`` is set, the live generator-management tools and
+        REST-API-fallback guidance in the server instructions.
 
     """
-    mcp = FastMCP('eventum', instructions=_INSTRUCTIONS)
+    instructions = (
+        f'{_INSTRUCTIONS} {_REST_API_NOTE}' if live else _INSTRUCTIONS
+    )
+    mcp = FastMCP('eventum', instructions=instructions)
     mcp._mcp_server.version = _eventum_version  # noqa: SLF001
 
     discovery.register(mcp, context, transport=transport)

--- a/eventum/mcp/tests/test_prompts.py
+++ b/eventum/mcp/tests/test_prompts.py
@@ -37,3 +37,20 @@ def test_live_ops_lists_the_workflow() -> None:
         'list_startup_generators',
     ):
         assert token in text
+
+
+def test_create_generator_surfaces_module_and_large_sample() -> None:
+    """The prompt names arbitrary imports and the large-sample path."""
+    text = create_generator_text()
+    assert 'module.<name>' in text
+    assert 'subprocess' in text
+    assert '/api/generator-configs/' in text
+
+
+def test_live_ops_covers_modes_and_scenarios() -> None:
+    """The live-ops prompt explains run modes and scenarios."""
+    text = live_ops_text()
+    assert 'live mode' in text
+    assert 'sample mode' in text
+    assert 'scenarios' in text
+    assert 'REST scenarios API' in text

--- a/eventum/mcp/tests/test_resources_templating.py
+++ b/eventum/mcp/tests/test_resources_templating.py
@@ -14,3 +14,13 @@ def test_reference_markdown_lists_rand_and_samples() -> None:
     assert '## `samples.<name>`' in text
     assert 'samples.<name>.where' in text
     assert '## `dispatch`' in text
+
+
+def test_markdown_surfaces_module_importer_and_subprocess() -> None:
+    """Rendered Markdown explains arbitrary imports and subprocess."""
+    text = render_templating_reference()
+    assert '## `module`' in text
+    assert 'installed' in text.lower()
+    assert '## `subprocess`' in text
+    assert 'subprocess.run' in text
+    assert '{% do %}' in text

--- a/eventum/mcp/tests/test_server.py
+++ b/eventum/mcp/tests/test_server.py
@@ -175,3 +175,33 @@ def test_stdio_has_no_live_ops_prompt(ctx: FileAuthoringContext) -> None:
     server = build_server(ctx, transport='stdio')
     names = {p.name for p in anyio.run(server.list_prompts)}
     assert 'live_ops' not in names
+
+
+def test_live_server_instructions_mention_rest_api(
+    live_ctx: ServerLiveContext,
+) -> None:
+    """The HTTP live server points the agent at the REST API."""
+    server = build_server(live_ctx, transport='http', live=True)
+    instructions = server.instructions or ''
+    assert 'REST API' in instructions
+    assert '/api/openapi.json' in instructions
+
+
+def test_stdio_instructions_omit_rest_api(
+    ctx: FileAuthoringContext,
+) -> None:
+    """The stdio server does not advertise a REST API fallback."""
+    server = build_server(ctx, transport='stdio')
+    instructions = server.instructions or ''
+    assert '/api/openapi.json' not in instructions
+
+
+def test_write_generator_file_warns_about_large_samples(
+    ctx: FileAuthoringContext,
+) -> None:
+    """The write tool steers large samples to an out-of-band upload."""
+    server = build_server(ctx, transport='stdio')
+    tools = anyio.run(server.list_tools)
+    tool = next(t for t in tools if t.name == 'write_generator_file')
+    description = tool.description or ''
+    assert 'out-of-band' in description

--- a/eventum/mcp/tools/workspace_files.py
+++ b/eventum/mcp/tools/workspace_files.py
@@ -454,7 +454,10 @@ def register(
         the server is read-only without touching the filesystem. Name
         the config file ``generator.yml`` unless this server is
         configured with another config filename - validate, preview,
-        and run load that filename.
+        and run load that filename. For a large CSV or JSON sample,
+        prefer an out-of-band upload (the REST file API over HTTP, or
+        a direct disk write when running locally) and reference it
+        from the config; passing big content here is slow.
 
         Parameters
         ----------

--- a/eventum/plugins/event/plugins/template/reference.py
+++ b/eventum/plugins/event/plugins/template/reference.py
@@ -1,11 +1,12 @@
 """Programmatic description of the template Jinja context surface.
 
 Introspects the live helper objects (the ``rand`` module and the
-``Sample``, ``Dispatcher``, ``State`` and ``MultiThreadState``
-classes) so the description cannot drift from the code: a new helper
-added to an existing namespace surfaces here with no extra step.
-Non-introspectable entries (external libraries, user-provided dicts,
-the event fields) are described in prose.
+``Sample``, ``Dispatcher``, ``State``, ``MultiThreadState`` and
+``SubprocessRunner`` classes) so the description cannot drift from
+the code: a new helper added to an existing namespace surfaces here
+with no extra step. Non-introspectable entries (the generic
+``module`` importer, external libraries, user-provided dicts, the
+event fields) are described in prose.
 """
 
 import inspect
@@ -17,6 +18,9 @@ from eventum.plugins.event.plugins.template.sample_reader import Sample
 from eventum.plugins.event.plugins.template.state import (
     MultiThreadState,
     State,
+)
+from eventum.plugins.event.plugins.template.subprocess_runner import (
+    SubprocessRunner,
 )
 
 
@@ -93,14 +97,28 @@ def build_context_reference() -> ContextReference:
     Returns
     -------
     ContextReference
-        Every namespace available to event templates: ``module.rand``
-        and its sub-namespaces, ``samples.<name>``, ``dispatch``, the
+        Every namespace available to event templates: the generic
+        ``module`` importer, ``module.rand`` and its sub-namespaces,
+        ``samples.<name>``, ``dispatch``, ``subprocess``, the
         ``locals``/``shared``/``globals`` state objects, and described
         entries (``module.faker``/``module.mimesis``, ``params``,
         ``vars``, ``timestamp``, ``tags``).
 
     """
     namespaces: list[Namespace] = []
+
+    namespaces.append(
+        Namespace(
+            'module',
+            'Import any Python module by name: module.<name> (also '
+            'module[name]). Resolves a bundled template module first '
+            '(rand, faker, mimesis), otherwise any package installed '
+            'in the environment (e.g. module.json, module.hashlib, '
+            'module.datetime). The bundled modules listed below are '
+            'not the whole set.',
+            (),
+        )
+    )
 
     namespaces.append(
         Namespace(
@@ -132,6 +150,14 @@ def build_context_reference() -> ContextReference:
             'dispatch',
             'Per-event control-flow signals.',
             _helpers(Dispatcher, Dispatcher.__module__),
+        )
+    )
+
+    namespaces.append(
+        Namespace(
+            'subprocess',
+            'Run shell commands from a template and read their output.',
+            _helpers(SubprocessRunner, SubprocessRunner.__module__),
         )
     )
 

--- a/eventum/plugins/event/plugins/template/tests/test_reference.py
+++ b/eventum/plugins/event/plugins/template/tests/test_reference.py
@@ -73,3 +73,67 @@ def test_globals_exposes_lock_methods_not_on_locals() -> None:
     loc = {h.name for h in by_path['locals'].helpers}
     assert {'acquire', 'release'} <= gl
     assert not ({'acquire', 'release'} & loc)
+
+
+def test_module_importer_and_subprocess_are_surfaced() -> None:
+    """The generic module importer and subprocess are present."""
+    ref = build_context_reference()
+    by_path = {ns.path: ns for ns in ref.namespaces}
+    assert 'module' in by_path
+    description = by_path['module'].description.lower()
+    assert 'import any' in description
+    assert 'installed' in description
+    assert by_path['module'].helpers == ()
+    subprocess_helpers = {h.name for h in by_path['subprocess'].helpers}
+    assert 'run' in subprocess_helpers
+
+
+def test_every_env_global_is_documented() -> None:
+    """Every env-level template global maps to a reference namespace.
+
+    Guards against drift: a global injected into the Jinja environment
+    (as ``subprocess`` once was) but missing from the reference fails
+    here.
+    """
+    from pathlib import Path
+
+    from jinja2 import DictLoader, Environment
+
+    from eventum.plugins.event.plugins.template.config import (
+        TemplateConfigForGeneralModes,
+        TemplateEventPluginConfig,
+        TemplateEventPluginConfigForGeneralModes,
+        TemplatePickingMode,
+    )
+    from eventum.plugins.event.plugins.template.plugin import (
+        TemplateEventPlugin,
+    )
+
+    plugin = TemplateEventPlugin(
+        config=TemplateEventPluginConfig(
+            root=TemplateEventPluginConfigForGeneralModes(
+                params={},
+                samples={},
+                mode=TemplatePickingMode.ALL,
+                templates=[
+                    {
+                        'event': TemplateConfigForGeneralModes(
+                            template=Path('event.jinja')
+                        )
+                    }
+                ],
+            )
+        ),
+        params={
+            'id': 1,
+            'templates_loader': DictLoader(mapping={'event.jinja': ''}),
+        },
+    )
+
+    builtins = set(Environment().globals)
+    injected = set(plugin._env.globals) - builtins  # noqa: SLF001
+    ref = build_context_reference()
+    documented = {ns.path.split('.')[0] for ns in ref.namespaces}
+
+    missing = injected - documented
+    assert not missing, f'undocumented template globals: {sorted(missing)}'


### PR DESCRIPTION
## Summary

Closes the gap between what Eventum can do and what the MCP server tells a connected agent. Seeded by #154 (large sample uploads through MCP are slow), then expanded to the broader "the agent doesn't know about capabilities" problem.

## Changes

- **Templating reference** (`plugins/event/template/reference.py`): new prose `module` namespace explaining `module.<name>` imports any installed Python package — not only the bundled `rand`/`faker`/`mimesis`; an introspected `subprocess` namespace; the resource intro now notes the importer and the enabled Jinja `do`/`loopcontrols` extensions.
- **REST API awareness** (`mcp/server.py`): the HTTP (live) server instructions point the agent at the REST API and its OpenAPI schema (`/api/openapi.json`) as a fallback when no MCP tool fits. Gated by the `live` capability, not by branching on transport.
- **#154 large samples** (`authoring` prompt + `write_generator_file` docstring): large CSV/JSON samples are steered to an out-of-band upload — the REST file API over HTTP, or a direct disk write when running locally — instead of the slow `write_generator_file` path. Also fixes the prompt line that implied `module` was only rand/faker/mimesis.
- **Modes & scenarios** (`live_ops` prompt): live vs sample run modes, and `globals`/scenario coordination with a pointer to the REST scenarios API.
- **Drift guard** (`template/tests/test_reference.py`): asserts every env-level template global is documented in the reference, so a future injected global (as `subprocess` once was) cannot silently go undocumented.

No new tools; no behaviour change beyond guiding text and docstrings. The MCP boundary is respected — no `eventum.api` import; the agent fetches the OpenAPI itself.

## Verification

- `ruff check` / `ruff format --check` / `mypy eventum/` — clean
- `pytest` — 1246 passed (integration/performance excluded)
- No UI change

## Note

The REST-API instruction assumes the REST API service is enabled (the normal full-server setup); the rare `mcp: true, api: false` combination would make it inaccurate — the agent would get a 404 and fall back.

Refs #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
