### PR TITLE
feat(app): nest server ui/api toggles, deprecate flat keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🚀 New Features
 
-- **Nested `server.ui` and `server.api` config sections** — the web UI and REST API toggles now live under `server.ui.enabled` and `server.api.enabled`, matching the `server.mcp` layout. The flat `server.ui_enabled` and `server.api_enabled` keys still work but are deprecated and print a notice at startup; combining a flat key with its nested form is rejected
+- **Nested `server.ui` and `server.api` config sections** — the web UI and REST API toggles now live under `server.ui.enabled` and `server.api.enabled`, matching the `server.mcp` layout. The flat `server.ui_enabled` and `server.api_enabled` keys still work but are deprecated, print a notice at startup, and will be removed in version 2.8; combining a flat key with its nested form is rejected
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### 🚀 New Features
+
+- **Nested `server.ui` and `server.api` config sections** — the web UI and REST API toggles now live under `server.ui.enabled` and `server.api.enabled`, matching the `server.mcp` layout. The flat `server.ui_enabled` and `server.api_enabled` keys still work but are deprecated and print a notice at startup; combining a flat key with its nested form is rejected
+
 ### 🐛 Bug Fixes
 
 - **Recreating a deleted project no longer shows the old project's settings** — creating a project with the same name as a deleted one now starts from a clean configuration; previously its plugin tabs could still display the deleted project's settings

--- a/config/eventum.yml
+++ b/config/eventum.yml
@@ -4,11 +4,11 @@
 
 # Whether to enable web UI
 # Optional, default is true
-server.ui_enabled: true
+server.ui.enabled: true
 
 # Whether to enable REST API
 # Optional, default is true
-server.api_enabled: true
+server.api.enabled: true
 
 # Bind address
 # Optional, default is "0.0.0.0"

--- a/eventum/app/main.py
+++ b/eventum/app/main.py
@@ -73,7 +73,7 @@ class App:
     def _server_enabled(self) -> bool:
         """Whether any server-hosted service is enabled."""
         server = self._settings.server
-        return server.api_enabled or server.ui_enabled or server.mcp.enabled
+        return server.api.enabled or server.ui.enabled or server.mcp.enabled
 
     def start(self) -> None:
         """Start the app.
@@ -275,8 +275,8 @@ class App:
 
         server_app = build_server_app(
             enabled_services={
-                'api': self._settings.server.api_enabled,
-                'ui': self._settings.server.ui_enabled,
+                'api': self._settings.server.api.enabled,
+                'ui': self._settings.server.ui.enabled,
                 'mcp': self._settings.server.mcp.enabled,
             },
             generator_manager=self._manager,

--- a/eventum/app/models/parameters/server.py
+++ b/eventum/app/models/parameters/server.py
@@ -185,9 +185,9 @@ class ServerParameters(BaseModel, extra='forbid', frozen=True):
     Notes
     -----
     The flat `ui_enabled` and `api_enabled` keys are deprecated
-    aliases for `ui.enabled` and `api.enabled`. They still work but
-    emit a deprecation warning and cannot be combined with their
-    nested counterparts.
+    aliases for `ui.enabled` and `api.enabled` and will be removed
+    in version 2.8. They still work but emit a deprecation warning
+    and cannot be combined with their nested counterparts.
 
     """
 
@@ -223,8 +223,8 @@ class ServerParameters(BaseModel, extra='forbid', frozen=True):
                 raise ValueError(msg)
 
             warnings.warn(
-                f'`server.{old_key}` is deprecated; use '
-                f'`server.{new_key}.enabled` instead',
+                f'`server.{old_key}` is deprecated and will be removed '
+                f'in version 2.8; use `server.{new_key}.enabled` instead',
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/eventum/app/models/parameters/server.py
+++ b/eventum/app/models/parameters/server.py
@@ -1,7 +1,8 @@
 """Server parameters."""
 
+import warnings
 from pathlib import Path
-from typing import Literal, Self
+from typing import Any, Literal, Self
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -129,16 +130,42 @@ class MCPParameters(BaseModel, extra='forbid', frozen=True):
         return v
 
 
+class UIParameters(BaseModel, extra='forbid', frozen=True):
+    """Web UI service parameters.
+
+    Attributes
+    ----------
+    enabled : bool, default=True
+        Whether to enable the web UI.
+
+    """
+
+    enabled: bool = Field(default=True)
+
+
+class APIParameters(BaseModel, extra='forbid', frozen=True):
+    """REST API service parameters.
+
+    Attributes
+    ----------
+    enabled : bool, default=True
+        Whether to enable the REST API.
+
+    """
+
+    enabled: bool = Field(default=True)
+
+
 class ServerParameters(BaseModel, extra='forbid', frozen=True):
     """Server parameters.
 
     Attributes
     ----------
-    ui_enabled : bool, default = True
-        Whether to enable web UI.
+    ui : UIParameters
+        Web UI service parameters.
 
-    api_enabled : bool, default = True
-        Whether to enable REST API.
+    api : APIParameters
+        REST API service parameters.
 
     host : str, default='0.0.0.0'
         Bind address for server process.
@@ -155,12 +182,52 @@ class ServerParameters(BaseModel, extra='forbid', frozen=True):
     mcp : MCPParameters
         MCP service parameters.
 
+    Notes
+    -----
+    The flat `ui_enabled` and `api_enabled` keys are deprecated
+    aliases for `ui.enabled` and `api.enabled`. They still work but
+    emit a deprecation warning and cannot be combined with their
+    nested counterparts.
+
     """
 
-    ui_enabled: bool = Field(default=True)
-    api_enabled: bool = Field(default=True)
+    ui: UIParameters = Field(default_factory=lambda: UIParameters())
+    api: APIParameters = Field(default_factory=lambda: APIParameters())
     host: str = Field(default='0.0.0.0', min_length=1)  # noqa: S104
     port: int = Field(default=9474, ge=1)
     ssl: SSLParameters = Field(default_factory=lambda: SSLParameters())
     auth: AuthParameters = Field(default_factory=lambda: AuthParameters())
     mcp: MCPParameters = Field(default_factory=lambda: MCPParameters())
+
+    @model_validator(mode='before')
+    @classmethod
+    def _migrate_deprecated_toggles(cls, data: Any) -> Any:
+        """Fold deprecated flat service toggles into nested sections."""
+        if not isinstance(data, dict):
+            return data
+
+        migrated = dict(data)
+        for old_key, new_key in (
+            ('ui_enabled', 'ui'),
+            ('api_enabled', 'api'),
+        ):
+            if old_key not in migrated:
+                continue
+
+            if new_key in migrated:
+                msg = (
+                    f'`server.{old_key}` is deprecated and cannot be '
+                    f'combined with `server.{new_key}`; use '
+                    f'`server.{new_key}.enabled` instead'
+                )
+                raise ValueError(msg)
+
+            warnings.warn(
+                f'`server.{old_key}` is deprecated; use '
+                f'`server.{new_key}.enabled` instead',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            migrated[new_key] = {'enabled': migrated.pop(old_key)}
+
+        return migrated

--- a/eventum/app/tests/test_main.py
+++ b/eventum/app/tests/test_main.py
@@ -11,8 +11,10 @@ from eventum.app.main import App, AppError
 from eventum.app.models.parameters.log import LogParameters
 from eventum.app.models.parameters.path import PathParameters
 from eventum.app.models.parameters.server import (
+    APIParameters,
     MCPParameters,
     ServerParameters,
+    UIParameters,
 )
 from eventum.app.models.settings import Settings
 from eventum.core.parameters import GenerationParameters
@@ -48,8 +50,8 @@ def _make_mcp_only_app(tmp_path: Path) -> App:
     settings = _make_settings(
         tmp_path,
         ServerParameters(
-            api_enabled=False,
-            ui_enabled=False,
+            ui=UIParameters(enabled=False),
+            api=APIParameters(enabled=False),
             mcp=MCPParameters(enabled=True),
         ),
     )
@@ -109,7 +111,10 @@ def test_start_skips_server_when_no_service_enabled(
     (tmp_path / 'startup.yml').write_text('[]')
     settings = _make_settings(
         tmp_path,
-        ServerParameters(api_enabled=False, ui_enabled=False),
+        ServerParameters(
+            ui=UIParameters(enabled=False),
+            api=APIParameters(enabled=False),
+        ),
     )
     app = App(settings=settings, instance_hooks=_make_hooks(settings))
 
@@ -204,8 +209,8 @@ def test_start_raises_when_address_is_in_use(tmp_path: Path) -> None:
         ServerParameters(
             host='127.0.0.1',
             port=port,
-            api_enabled=False,
-            ui_enabled=False,
+            ui=UIParameters(enabled=False),
+            api=APIParameters(enabled=False),
             mcp=MCPParameters(enabled=True),
         ),
     )

--- a/eventum/app/tests/test_models_parameters.py
+++ b/eventum/app/tests/test_models_parameters.py
@@ -8,10 +8,12 @@ from pydantic import ValidationError
 from eventum.app.models.parameters.log import LogParameters
 from eventum.app.models.parameters.path import PathParameters
 from eventum.app.models.parameters.server import (
+    APIParameters,
     AuthParameters,
     MCPParameters,
     ServerParameters,
     SSLParameters,
+    UIParameters,
 )
 
 # --- PathParameters ---
@@ -171,8 +173,8 @@ def test_server_parameters_defaults():
     params = ServerParameters()
     assert params.port == 9474
     assert params.host == '0.0.0.0'
-    assert params.ui_enabled is True
-    assert params.api_enabled is True
+    assert params.ui.enabled is True
+    assert params.api.enabled is True
 
 
 def test_server_parameters_port_zero_raises():
@@ -188,6 +190,56 @@ def test_server_parameters_port_one_passes():
 def test_server_parameters_includes_mcp_defaults() -> None:
     """ServerParameters exposes nested MCP defaults."""
     assert ServerParameters().mcp.enabled is False
+
+
+def test_ui_parameters_default_enabled() -> None:
+    """UIParameters is enabled by default."""
+    assert UIParameters().enabled is True
+
+
+def test_api_parameters_default_enabled() -> None:
+    """APIParameters is enabled by default."""
+    assert APIParameters().enabled is True
+
+
+def test_server_parameters_nested_toggles() -> None:
+    """Nested UI and API sections drive the service toggles."""
+    params = ServerParameters(
+        ui=UIParameters(enabled=False),
+        api=APIParameters(enabled=False),
+    )
+    assert params.ui.enabled is False
+    assert params.api.enabled is False
+
+
+def test_server_parameters_ui_enabled_alias_maps_to_nested() -> None:
+    """Deprecated `ui_enabled` folds into `ui.enabled` with a warning."""
+    with pytest.warns(DeprecationWarning, match='ui_enabled'):
+        params = ServerParameters.model_validate({'ui_enabled': False})
+    assert params.ui.enabled is False
+
+
+def test_server_parameters_api_enabled_alias_maps_to_nested() -> None:
+    """Deprecated `api_enabled` folds into `api.enabled` with a warning."""
+    with pytest.warns(DeprecationWarning, match='api_enabled'):
+        params = ServerParameters.model_validate({'api_enabled': False})
+    assert params.api.enabled is False
+
+
+def test_server_parameters_ui_alias_conflict_raises() -> None:
+    """Setting both `ui_enabled` and `ui` together is rejected."""
+    with pytest.raises(ValidationError, match='deprecated'):
+        ServerParameters.model_validate(
+            {'ui_enabled': True, 'ui': {'enabled': False}},
+        )
+
+
+def test_server_parameters_api_alias_conflict_raises() -> None:
+    """Setting both `api_enabled` and `api` together is rejected."""
+    with pytest.raises(ValidationError, match='deprecated'):
+        ServerParameters.model_validate(
+            {'api_enabled': True, 'api': {'enabled': False}},
+        )
 
 
 # --- LogParameters ---

--- a/eventum/cli/commands/eventum.py
+++ b/eventum/cli/commands/eventum.py
@@ -3,6 +3,7 @@
 import os
 import signal
 import sys
+import warnings
 from pathlib import Path
 from typing import Literal, NoReturn
 
@@ -66,18 +67,24 @@ def _start_app_instance(config: str) -> App:
         )
         sys.exit(1)
 
-    try:
-        settings = Settings.model_validate(data)
-    except ValidationError as e:
-        click.echo(
-            (
-                'Error: Failed to validate settings:'
-                + os.linesep
-                + prettify_validation_errors(e.errors(), sep=os.linesep)
-            ),
-            err=True,
-        )
-        sys.exit(1)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always', DeprecationWarning)
+        try:
+            settings = Settings.model_validate(data)
+        except ValidationError as e:
+            click.echo(
+                (
+                    'Error: Failed to validate settings:'
+                    + os.linesep
+                    + prettify_validation_errors(e.errors(), sep=os.linesep)
+                ),
+                err=True,
+            )
+            sys.exit(1)
+
+    for warning in caught:
+        if issubclass(warning.category, DeprecationWarning):
+            click.echo(f'Warning: {warning.message}', err=True)
 
     # Since current function can be called many times, we should clear logconf
     logconf.clear()

--- a/eventum/cli/tests/test_commands_eventum.py
+++ b/eventum/cli/tests/test_commands_eventum.py
@@ -27,6 +27,8 @@ CONFLICTING_SERVER_SECTION = (
     'server:\n  mcp.enabled: true\n  mcp:\n    enabled: false\n'
 )
 
+DEPRECATED_TOGGLE_SECTION = 'server:\n  ui_enabled: false\n'
+
 
 def _write_config(
     tmp_path: Path,
@@ -94,3 +96,22 @@ def test_start_app_instance_conflicting_dotted_keys(
     captured = capsys.readouterr()
     assert 'Failed to parse configuration YAML content' in captured.err
     assert 'server.mcp.enabled' in captured.err
+
+
+def test_start_app_instance_warns_on_deprecated_toggle(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Deprecated `ui_enabled` loads but prints a deprecation notice."""
+    config_path = _write_config(
+        tmp_path,
+        DEPRECATED_TOGGLE_SECTION,
+        'deprecated.yml',
+    )
+
+    settings = _start_app(config_path)
+
+    assert settings.server.ui.enabled is False
+    captured = capsys.readouterr()
+    assert 'server.ui_enabled' in captured.err
+    assert 'deprecated' in captured.err

--- a/eventum/ui/src/api/routes/instance/schemas.ts
+++ b/eventum/ui/src/api/routes/instance/schemas.ts
@@ -51,9 +51,17 @@ export const AuthParametersSchema = z.object({
   password: z.preprocess(emptyToUndefined, z.string().min(1).optional()),
 });
 
+export const UIParametersSchema = z.object({
+  enabled: z.boolean().optional(),
+});
+
+export const APIParametersSchema = z.object({
+  enabled: z.boolean().optional(),
+});
+
 export const ServerParametersSchema = z.object({
-  ui_enabled: z.boolean().optional(),
-  api_enabled: z.boolean().optional(),
+  ui: UIParametersSchema.optional(),
+  api: APIParametersSchema.optional(),
   host: z.preprocess(emptyToUndefined, z.string().min(1).optional()),
   port: z.preprocess(
     emptyToUndefined,

--- a/eventum/ui/src/pages/SettingsPage/ServerParametersSection/index.tsx
+++ b/eventum/ui/src/pages/SettingsPage/ServerParametersSection/index.tsx
@@ -35,8 +35,8 @@ export const ServerParametersSection: FC<ServerParametersSectionProps> = ({
               tooltip="Eventum API is used for external app control and for serving web interface"
             />
           }
-          {...form.getInputProps('api_enabled', { type: 'checkbox' })}
-          key={form.key('api_enabled')}
+          {...form.getInputProps('api.enabled', { type: 'checkbox' })}
+          key={form.key('api.enabled')}
         />
         <Switch
           label={
@@ -45,8 +45,8 @@ export const ServerParametersSection: FC<ServerParametersSectionProps> = ({
               tooltip="Whether to enable web interface service that you are currently use"
             />
           }
-          {...form.getInputProps('ui_enabled', { type: 'checkbox' })}
-          key={form.key('ui_enabled')}
+          {...form.getInputProps('ui.enabled', { type: 'checkbox' })}
+          key={form.key('ui.enabled')}
         />
       </Group>
 
@@ -54,7 +54,7 @@ export const ServerParametersSection: FC<ServerParametersSectionProps> = ({
         variant="default"
         icon={<Box c="orange" component={IconAlertTriangle}></Box>}
         title="Disabling API"
-        hidden={form.getValues().api_enabled}
+        hidden={form.getValues().api?.enabled}
       >
         Web interface will not be functional after disabling API.
       </Alert>
@@ -69,8 +69,8 @@ export const ServerParametersSection: FC<ServerParametersSectionProps> = ({
           placeholder="hostname or IP"
           disabled={
             !(
-              form.getValues().api_enabled === true ||
-              form.getValues().ui_enabled === true
+              form.getValues().api?.enabled === true ||
+              form.getValues().ui?.enabled === true
             )
           }
           {...form.getInputProps('host')}
@@ -89,8 +89,8 @@ export const ServerParametersSection: FC<ServerParametersSectionProps> = ({
           max={65_535}
           disabled={
             !(
-              form.getValues().api_enabled === true ||
-              form.getValues().ui_enabled === true
+              form.getValues().api?.enabled === true ||
+              form.getValues().ui?.enabled === true
             )
           }
           {...form.getInputProps('port')}
@@ -105,8 +105,8 @@ export const ServerParametersSection: FC<ServerParametersSectionProps> = ({
         label="Enable SSL"
         disabled={
           !(
-            form.getValues().api_enabled === true ||
-            form.getValues().ui_enabled === true
+            form.getValues().api?.enabled === true ||
+            form.getValues().ui?.enabled === true
           )
         }
         {...form.getInputProps('ssl.enabled', {
@@ -133,8 +133,8 @@ export const ServerParametersSection: FC<ServerParametersSectionProps> = ({
               <Radio
                 disabled={
                   !(
-                    form.getValues().api_enabled === true ||
-                    form.getValues().ui_enabled === true
+                    form.getValues().api?.enabled === true ||
+                    form.getValues().ui?.enabled === true
                   ) || !form.getValues().ssl?.enabled
                 }
                 value="none"
@@ -153,8 +153,8 @@ export const ServerParametersSection: FC<ServerParametersSectionProps> = ({
               <Radio
                 disabled={
                   !(
-                    form.getValues().api_enabled === true ||
-                    form.getValues().ui_enabled === true
+                    form.getValues().api?.enabled === true ||
+                    form.getValues().ui?.enabled === true
                   ) || !form.getValues().ssl?.enabled
                 }
                 value="optional"
@@ -173,8 +173,8 @@ export const ServerParametersSection: FC<ServerParametersSectionProps> = ({
               <Radio
                 disabled={
                   !(
-                    form.getValues().api_enabled === true ||
-                    form.getValues().ui_enabled === true
+                    form.getValues().api?.enabled === true ||
+                    form.getValues().ui?.enabled === true
                   ) || !form.getValues().ssl?.enabled
                 }
                 value="required"
@@ -194,8 +194,8 @@ export const ServerParametersSection: FC<ServerParametersSectionProps> = ({
         placeholder="/path/to/ca-cert.pem"
         disabled={
           !(
-            form.getValues().api_enabled === true ||
-            form.getValues().ui_enabled === true
+            form.getValues().api?.enabled === true ||
+            form.getValues().ui?.enabled === true
           ) || !form.getValues().ssl?.enabled
         }
         {...form.getInputProps('ssl.ca_cert')}
@@ -211,8 +211,8 @@ export const ServerParametersSection: FC<ServerParametersSectionProps> = ({
         placeholder="/path/to/cert.pem"
         disabled={
           !(
-            form.getValues().api_enabled === true ||
-            form.getValues().ui_enabled === true
+            form.getValues().api?.enabled === true ||
+            form.getValues().ui?.enabled === true
           ) || !form.getValues().ssl?.enabled
         }
         {...form.getInputProps('ssl.cert')}
@@ -228,8 +228,8 @@ export const ServerParametersSection: FC<ServerParametersSectionProps> = ({
         placeholder="/path/to/key.pem"
         disabled={
           !(
-            form.getValues().api_enabled === true ||
-            form.getValues().ui_enabled === true
+            form.getValues().api?.enabled === true ||
+            form.getValues().ui?.enabled === true
           ) || !form.getValues().ssl?.enabled
         }
         {...form.getInputProps('ssl.cert_key')}
@@ -249,8 +249,8 @@ export const ServerParametersSection: FC<ServerParametersSectionProps> = ({
           }
           disabled={
             !(
-              form.getValues().api_enabled === true ||
-              form.getValues().ui_enabled === true
+              form.getValues().api?.enabled === true ||
+              form.getValues().ui?.enabled === true
             )
           }
           {...form.getInputProps('auth.user')}
@@ -265,8 +265,8 @@ export const ServerParametersSection: FC<ServerParametersSectionProps> = ({
           }
           disabled={
             !(
-              form.getValues().api_enabled === true ||
-              form.getValues().ui_enabled === true
+              form.getValues().api?.enabled === true ||
+              form.getValues().ui?.enabled === true
             )
           }
           {...form.getInputProps('auth.password')}


### PR DESCRIPTION
## Summary

Refs #159 — moves the web UI and REST API toggles into nested `server.ui.enabled` and `server.api.enabled` sections, mirroring `server.mcp`.

The flat `server.ui_enabled` and `server.api_enabled` keys remain as **deprecated aliases**: they fold into the nested form and print a deprecation notice at startup. Setting a flat key together with its nested counterpart is rejected as a validation error.

## Changes

- `app/models/parameters/server.py` — new `UIParameters` / `APIParameters` models; `ui` / `api` fields on `ServerParameters`; a before-validator that migrates the deprecated flat keys (warns, and guards against combining old and new)
- `app/main.py` — reads `server.ui.enabled` / `server.api.enabled`
- `cli/commands/eventum.py` — surfaces deprecation warnings from config validation to stderr
- `config/eventum.yml`, `CHANGELOG.md` — updated to the nested form
- Tests for alias migration, conflict, defaults, and the CLI startup notice

## Verification

- `ruff check .` / `ruff format --check .` — pass
- `mypy eventum/` — pass
- `pytest` — 1273 passed (integration excluded)

Documentation changes are submitted as a separate PR in the docs repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
