### PR TITLE
feat(ui): add clone action for generator instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### 🚀 New Features
+
+- **Clone an instance in Studio** — the instance row menu now has a **Clone** action that creates a new instance from an existing one, reusing its project and all parameters; you only choose a name for the clone
+
 ### 🐛 Bug Fixes
 
 - **Recreating a deleted project no longer shows the old project's settings** — creating a project with the same name as a deleted one now starts from a clean configuration; previously its plugin tabs could still display the deleted project's settings

--- a/eventum/ui/src/pages/InstancesPage/CloneInstanceModal.tsx
+++ b/eventum/ui/src/pages/InstancesPage/CloneInstanceModal.tsx
@@ -1,0 +1,225 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Center,
+  Container,
+  Group,
+  Loader,
+  Stack,
+  Text,
+  TextInput,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { modals } from '@mantine/modals';
+import { notifications } from '@mantine/notifications';
+import { IconAlertSquareRounded } from '@tabler/icons-react';
+import { FC } from 'react';
+
+import {
+  useAddGeneratorMutation,
+  useGenerator,
+} from '@/api/hooks/useGenerators';
+import {
+  useAddGeneratorToStartupMutation,
+  useStartupGenerator,
+} from '@/api/hooks/useStartup';
+import { GeneratorParametersSchema } from '@/api/routes/generators/schemas';
+import { StartupGeneratorParameters } from '@/api/routes/startup/schemas';
+import { ShowErrorDetailsAnchor } from '@/components/ui/ShowErrorDetailsAnchor';
+
+interface CloneInstanceModalProps {
+  sourceInstanceId: string;
+  existingInstanceIds: string[];
+}
+
+function suggestCloneName(sourceId: string, existingIds: string[]): string {
+  const base = `${sourceId}-clone`;
+
+  if (!existingIds.includes(base)) {
+    return base;
+  }
+
+  let suffix = 2;
+  while (existingIds.includes(`${base}-${suffix}`)) {
+    suffix += 1;
+  }
+
+  return `${base}-${suffix}`;
+}
+
+export const CloneInstanceModal: FC<CloneInstanceModalProps> = ({
+  sourceInstanceId,
+  existingInstanceIds,
+}) => {
+  const form = useForm<{ id: string }>({
+    initialValues: {
+      id: suggestCloneName(sourceInstanceId, existingInstanceIds),
+    },
+    validate: {
+      id: (value) => {
+        if (!value) {
+          return 'Instance name is required';
+        }
+        if (existingInstanceIds.includes(value)) {
+          return 'Instance with this name already exists';
+        }
+
+        return null;
+      },
+    },
+    validateInputOnChange: true,
+    onSubmitPreventDefault: 'always',
+  });
+
+  const {
+    data: generatorParams,
+    isLoading: isGeneratorParamsLoading,
+    isError: isGeneratorParamsError,
+    error: generatorParamsError,
+    isSuccess: isGeneratorParamsSuccess,
+  } = useGenerator(sourceInstanceId);
+
+  const {
+    data: startupGeneratorParams,
+    isLoading: isStartupGeneratorParamsLoading,
+    isError: isStartupGeneratorParamsError,
+    error: startupGeneratorParamsError,
+    isSuccess: isStartupGeneratorParamsSuccess,
+  } = useStartupGenerator(sourceInstanceId);
+
+  const addGenerator = useAddGeneratorMutation();
+  const addGeneratorToStartup = useAddGeneratorToStartupMutation();
+
+  function handleCloneInstance(values: typeof form.values) {
+    if (generatorParams === undefined || startupGeneratorParams === undefined) {
+      return;
+    }
+
+    const params: StartupGeneratorParameters = {
+      ...generatorParams,
+      autostart: startupGeneratorParams.autostart,
+      scenarios: startupGeneratorParams.scenarios ?? [],
+      id: values.id,
+    };
+
+    addGenerator.mutate(
+      { id: values.id, params: GeneratorParametersSchema.parse(params) },
+      {
+        onSuccess: () => {
+          addGeneratorToStartup.mutate(
+            { id: values.id, params },
+            {
+              onSuccess: () => {
+                notifications.show({
+                  title: 'Success',
+                  message: 'Instance is cloned',
+                  color: 'green',
+                });
+                modals.closeAll();
+              },
+              onError: (error) => {
+                notifications.show({
+                  title: 'Error',
+                  message: (
+                    <>
+                      Failed to add instance definition to startup
+                      <ShowErrorDetailsAnchor error={error} prependDot />
+                    </>
+                  ),
+                  color: 'red',
+                });
+              },
+            }
+          );
+        },
+        onError: (error) => {
+          notifications.show({
+            title: 'Error',
+            message: (
+              <>
+                Failed to clone instance
+                <ShowErrorDetailsAnchor error={error} prependDot />
+              </>
+            ),
+            color: 'red',
+          });
+        },
+      }
+    );
+  }
+
+  if (isGeneratorParamsLoading || isStartupGeneratorParamsLoading) {
+    return (
+      <Center>
+        <Loader size="lg" />
+      </Center>
+    );
+  }
+
+  if (isGeneratorParamsError) {
+    return (
+      <Container size="md">
+        <Alert
+          variant="default"
+          icon={<Box c="red" component={IconAlertSquareRounded}></Box>}
+          title="Failed to get instance parameters"
+        >
+          {generatorParamsError.message}
+          <ShowErrorDetailsAnchor error={generatorParamsError} prependDot />
+        </Alert>
+      </Container>
+    );
+  }
+
+  if (isStartupGeneratorParamsError) {
+    return (
+      <Container size="md">
+        <Alert
+          variant="default"
+          icon={<Box c="red" component={IconAlertSquareRounded}></Box>}
+          title="Failed to get startup instance parameters"
+        >
+          {startupGeneratorParamsError.message}
+          <ShowErrorDetailsAnchor
+            error={startupGeneratorParamsError}
+            prependDot
+          />
+        </Alert>
+      </Container>
+    );
+  }
+
+  if (isGeneratorParamsSuccess && isStartupGeneratorParamsSuccess) {
+    return (
+      <form onSubmit={form.onSubmit(handleCloneInstance)}>
+        <Stack>
+          <Text size="sm" c="gray.6">
+            Cloning <b>{sourceInstanceId}</b> with all its parameters.
+          </Text>
+
+          <TextInput
+            label="New instance name"
+            placeholder="name"
+            required
+            {...form.getInputProps('id')}
+          />
+
+          <Group justify="end">
+            <Button
+              disabled={!form.isValid()}
+              loading={
+                addGenerator.isPending || addGeneratorToStartup.isPending
+              }
+              type="submit"
+            >
+              Clone
+            </Button>
+          </Group>
+        </Stack>
+      </form>
+    );
+  }
+
+  return null;
+};

--- a/eventum/ui/src/pages/InstancesPage/InstancesTable/RowActions.tsx
+++ b/eventum/ui/src/pages/InstancesPage/InstancesTable/RowActions.tsx
@@ -2,6 +2,7 @@ import { Menu, Text } from '@mantine/core';
 import { modals } from '@mantine/modals';
 import { notifications } from '@mantine/notifications';
 import {
+  IconCopy,
   IconEdit,
   IconGauge,
   IconLogs,
@@ -12,6 +13,7 @@ import {
 import { FC, ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { CloneInstanceModal } from '../CloneInstanceModal';
 import { MetricsModal } from './MetricsModal';
 import {
   useDeleteGeneratorMutation,
@@ -30,12 +32,14 @@ interface RowActionsProps {
   target: ReactNode;
   instanceId: string;
   instanceStatus: GeneratorStatus;
+  existingInstanceIds: string[];
 }
 
 export const RowActions: FC<RowActionsProps> = ({
   target,
   instanceId,
   instanceStatus,
+  existingInstanceIds,
 }) => {
   const navigate = useNavigate();
   const startGenerator = useStartGeneratorMutation();
@@ -46,6 +50,19 @@ export const RowActions: FC<RowActionsProps> = ({
 
   function handleEdit() {
     void navigate(`${ROUTE_PATHS.INSTANCES}/${instanceId}`);
+  }
+
+  function handleClone() {
+    modals.open({
+      title: 'Clone instance',
+      children: (
+        <CloneInstanceModal
+          sourceInstanceId={instanceId}
+          existingInstanceIds={existingInstanceIds}
+        />
+      ),
+      size: 'lg',
+    });
   }
 
   function handleShowMetrics() {
@@ -197,6 +214,9 @@ export const RowActions: FC<RowActionsProps> = ({
       <Menu.Dropdown>
         <Menu.Item leftSection={<IconEdit size={14} />} onClick={handleEdit}>
           Edit
+        </Menu.Item>
+        <Menu.Item leftSection={<IconCopy size={14} />} onClick={handleClone}>
+          Clone
         </Menu.Item>
 
         <Menu.Divider />

--- a/eventum/ui/src/pages/InstancesPage/InstancesTable/columns.tsx
+++ b/eventum/ui/src/pages/InstancesPage/InstancesTable/columns.tsx
@@ -134,8 +134,11 @@ export const columns = [
   }),
   columnHelper.display({
     id: 'actions',
-    cell: ({ row }) => {
+    cell: ({ row, table }) => {
       const original = row.original;
+      const existingInstanceIds = table.options.data.map(
+        (instance) => instance.id
+      );
       return (
         <RowActions
           target={
@@ -145,6 +148,7 @@ export const columns = [
           }
           instanceId={original.id}
           instanceStatus={original.status}
+          existingInstanceIds={existingInstanceIds}
         />
       );
     },


### PR DESCRIPTION
## Summary

Adds a **Clone** action to the instance row menu on the Studio Instances page. It creates a new instance from an existing one, reusing its project and carrying over all of the original's parameters (live mode, skip past, template params, generation parameters, autostart, scenarios). The user only picks a name for the clone, pre-filled with `<id>-clone`.

Frontend-only — it composes the existing `generators` and `startup` endpoints (read the source config, register the clone under a new id), so there are no backend changes.

## Changes

- `CloneInstanceModal.tsx` (new) — reads the source instance config and registers the clone under a new, unique id
- `RowActions.tsx` — new **Clone** menu item next to **Edit**
- `columns.tsx` — passes existing instance ids down for name-uniqueness validation
- `CHANGELOG.md` — Unreleased / New Features entry

## Verification

- `pnpm build` (tsc + vite): green
- ESLint + Prettier on changed files: clean

## Notes

- The docs page update (`studio/instances.mdx`) lives in the separate `docs/` repo and is handled outside this PR.
- The UI has no test runner (tsc + ESLint + Vite build are the gates), so no frontend tests are included.

Refs #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)
