### PR TITLE
docs: always load .claude/rules by dropping path scoping

### DIFF
--- a/.claude/rules/backend/api.md
+++ b/.claude/rules/backend/api.md
@@ -1,8 +1,3 @@
----
-paths:
-  - "eventum/api/**"
----
-
 # API Development Rules
 
 ## Entry point

--- a/.claude/rules/backend/app.md
+++ b/.claude/rules/backend/app.md
@@ -1,8 +1,3 @@
----
-paths:
-  - "eventum/app/**"
----
-
 # App Rules
 
 ## Configuration models

--- a/.claude/rules/backend/core.md
+++ b/.claude/rules/backend/core.md
@@ -1,8 +1,3 @@
----
-paths:
-  - "eventum/core/**"
----
-
 # Core Rules
 
 ## Configuration models

--- a/.claude/rules/backend/exceptions.md
+++ b/.claude/rules/backend/exceptions.md
@@ -1,8 +1,3 @@
----
-paths:
-  - "eventum/**/*.py"
----
-
 # Exception Rules
 
 `ContextualError` (`eventum/exceptions.py`) - base exception with required `context: dict` kwarg.

--- a/.claude/rules/backend/logging.md
+++ b/.claude/rules/backend/logging.md
@@ -1,8 +1,3 @@
----
-paths:
-  - "eventum/**/*.py"
----
-
 # Logging Rules
 
 Eventum logs through `structlog` over stdlib. Output is split into streams:

--- a/.claude/rules/backend/mcp.md
+++ b/.claude/rules/backend/mcp.md
@@ -1,8 +1,3 @@
----
-paths:
-  - "eventum/mcp/**/*.py"
----
-
 # MCP Adapter Rules
 
 `eventum/mcp/` is a transport-only driver adapter (peer to `api/`,

--- a/.claude/rules/backend/plugins.md
+++ b/.claude/rules/backend/plugins.md
@@ -1,8 +1,3 @@
----
-paths:
-  - "eventum/plugins/**/*.py"
----
-
 # Plugin Rules
 
 Common rules for all plugin types. Type-specific plugin contracts live in `.claude/rules/backend/plugins/{input,event,output}.md` and are auto-loaded when working under `eventum/plugins/<type>/`.

--- a/.claude/rules/backend/plugins/event.md
+++ b/.claude/rules/backend/plugins/event.md
@@ -1,8 +1,3 @@
----
-paths:
-  - "eventum/plugins/event/**/*.py"
----
-
 # Event Plugin Rules
 
 Event plugins turn a timestamp into zero or more event strings. Pipeline executor calls `_produce` per timestamp and forwards the returned list to the output stage.

--- a/.claude/rules/backend/plugins/input.md
+++ b/.claude/rules/backend/plugins/input.md
@@ -1,8 +1,3 @@
----
-paths:
-  - "eventum/plugins/input/**/*.py"
----
-
 # Input Plugin Rules
 
 Input plugins generate timestamps that drive event generation. The framework pulls chunks from the plugin by requesting a size, and the plugin yields numpy arrays until it exhausts.

--- a/.claude/rules/backend/plugins/output.md
+++ b/.claude/rules/backend/plugins/output.md
@@ -1,8 +1,3 @@
----
-paths:
-  - "eventum/plugins/output/**/*.py"
----
-
 # Output Plugin Rules
 
 Output plugins deliver event strings to a destination (file, socket, broker, etc.). Output plugins have an explicit async lifecycle: `_open` to acquire the destination, `_write` to push batches, `_close` to release.

--- a/.claude/rules/backend/server.md
+++ b/.claude/rules/backend/server.md
@@ -1,8 +1,3 @@
----
-paths:
-  - "eventum/server/**/*.py"
----
-
 # Server Rules
 
 ## Transport only

--- a/.claude/rules/content/generators.md
+++ b/.claude/rules/content/generators.md
@@ -1,8 +1,3 @@
----
-paths:
-  - "../content-packs/generators/**"
----
-
 # Generator Rules
 
 Content-packs (`../content-packs/`) is the companion repository shipping ready-to-use generators. A generator is a self-contained project under `generators/<category>-<source>/` producing realistic synthetic events that mimic a real data source.

--- a/.claude/rules/content/templates.md
+++ b/.claude/rules/content/templates.md
@@ -1,8 +1,3 @@
----
-paths:
-  - "../content-packs/generators/**/templates/**/*.jinja"
----
-
 # Template Plugin Rules
 
 The template event plugin renders events from Jinja2 templates per timestamp. All existing content-pack generators use it.

--- a/.claude/rules/docs/blog.md
+++ b/.claude/rules/docs/blog.md
@@ -1,8 +1,3 @@
----
-paths:
-  - "../docs/content/blog/**/*.mdx"
----
-
 # Blog Post Rules
 
 Blog posts live in `../docs/content/blog/` - release announcements, launches, feature highlights. Journalistic storytelling, not reference.

--- a/.claude/rules/docs/hub.md
+++ b/.claude/rules/docs/hub.md
@@ -1,8 +1,3 @@
----
-paths:
-  - "../docs/lib/hub-data/**/*.ts"
----
-
 # Hub Rules
 
 The Hub is a catalog of content-pack generators at `/hub`. Entries are TypeScript data files under `../docs/lib/hub-data/` - the UI reads them at build time.

--- a/.claude/rules/docs/mdx.md
+++ b/.claude/rules/docs/mdx.md
@@ -1,10 +1,3 @@
----
-paths:
-  - "../docs/content/docs/**/*.mdx"
-  - "../docs/app/**/*.mdx"
-  - "../docs/**/meta.json"
----
-
 # MDX Documentation Rules
 
 The docs site is Next.js + Fumadocs, static-exported to https://eventum.run. Technical content lives in `../docs/content/docs/` (Fumadocs MDX collections); top-level pages in `../docs/app/` (Next.js routes). Blog posts have their own rules described in `blog.md`.

--- a/.claude/rules/frontend/ui.md
+++ b/.claude/rules/frontend/ui.md
@@ -1,8 +1,3 @@
----
-paths:
-  - "eventum/ui/src/**/*.{ts,tsx}"
----
-
 # UI Rules
 
 Eventum Studio is a React + TypeScript SPA built on Mantine, react-query, Zod, and Vite.


### PR DESCRIPTION
Removes the `paths:` frontmatter from every `.claude/rules/*.md` so the area rules load **unconditionally at session start** instead of only when a file matching their globs is touched.

Per Claude Code's documented behavior, a rule with no `paths` field is loaded eagerly (same priority as `CLAUDE.md`); a rule with `paths` is lazy/path-scoped. Dropping the field makes every area rule always available - so cross-cutting rules (e.g. "every backend Pydantic model has a mirror Zod schema") are in context during planning, not just after a matching file is opened.

Trade-off: every session (and CI) now loads all rules (~38 KB). Scoping metadata is dropped; each rule's heading still names its area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)