### PR TITLE
feat(app): scope network and disk metrics to the application process

### DIFF
--- a/eventum/app/main.py
+++ b/eventum/app/main.py
@@ -17,6 +17,7 @@ from eventum.app.startup import (
 )
 from eventum.exceptions import ContextualError
 from eventum.security.manage import SECURITY_SETTINGS
+from eventum.utils import net_accounting
 
 logger = structlog.stdlib.get_logger()
 
@@ -84,6 +85,8 @@ class App:
             If error occurs during initialization.
 
         """
+        net_accounting.install()
+
         logger.info('Loading generators list')
         generators_params = self._load_startup_generators_params()
 

--- a/eventum/app/models/instance.py
+++ b/eventum/app/models/instance.py
@@ -8,6 +8,9 @@ import psutil
 from pydantic import BaseModel, Field, computed_field
 
 import eventum
+from eventum.utils.net_accounting import bytes_received, bytes_sent
+
+_PROCESS = psutil.Process()
 
 
 class InstanceInfo(BaseModel, extra='forbid', frozen=True):
@@ -93,35 +96,33 @@ class InstanceInfo(BaseModel, extra='forbid', frozen=True):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def network_sent_bytes(self) -> int:
-        """Number of sent bytes using network."""
-        return psutil.net_io_counters().bytes_sent
+        """Number of bytes sent over network by this application."""
+        return bytes_sent()
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def network_received_bytes(self) -> int:
-        """Number of received bytes using network."""
-        return psutil.net_io_counters().bytes_recv
+        """Number of bytes received over network by this application."""
+        return bytes_received()
 
     # Disk IO
     @computed_field  # type: ignore[prop-decorator]
     @property
     def disk_written_bytes(self) -> int:
-        """Number of written bytes."""
-        counters = psutil.disk_io_counters()
-        if counters is None:
+        """Number of bytes written to disk by this application."""
+        try:
+            return _PROCESS.io_counters().write_bytes
+        except psutil.Error, OSError:
             return 0
-
-        return counters.write_bytes
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def disk_read_bytes(self) -> int:
-        """Number of read bytes."""
-        counters = psutil.disk_io_counters()
-        if counters is None:
+        """Number of bytes read from disk by this application."""
+        try:
+            return _PROCESS.io_counters().read_bytes
+        except psutil.Error, OSError:
             return 0
-
-        return counters.read_bytes
 
     # Time
     boot_timestamp: float = Field(

--- a/eventum/utils/net_accounting.py
+++ b/eventum/utils/net_accounting.py
@@ -1,0 +1,112 @@
+"""In-process network byte accounting.
+
+psutil reports network counters only system-wide (``net_io_counters``),
+never per process, and the operating system exposes no portable
+per-process network byte counter. To report how much traffic *this
+application* moves, this module wraps the send and receive methods of
+``socket.socket`` so every byte the process passes through a Python
+socket is counted.
+
+Eventum's network output plugins (tcp, udp, http and opensearch via
+httpx, kafka via aiokafka, clickhouse) all run on asyncio and route
+through Python sockets, so the counters reflect the application's real
+network I/O - including TLS, whose encrypted bytes reach the raw socket.
+Counts are cumulative since ``install`` was called.
+"""
+
+import socket
+import threading
+
+_lock = threading.Lock()
+_sent = 0
+_received = 0
+_installed = False
+
+
+def bytes_sent() -> int:
+    """Return total bytes sent by this process since ``install``."""
+    return _sent
+
+
+def bytes_received() -> int:
+    """Return total bytes received by this process since ``install``."""
+    return _received
+
+
+def _buflen(data: object) -> int:
+    """Return the number of bytes in a bytes-like object."""
+    return memoryview(data).nbytes  # type: ignore[arg-type]
+
+
+def _add_sent(count: int) -> None:
+    global _sent  # noqa: PLW0603
+    if count:
+        with _lock:
+            _sent += count
+
+
+def _add_received(count: int) -> None:
+    global _received  # noqa: PLW0603
+    if count:
+        with _lock:
+            _received += count
+
+
+def install() -> None:
+    """Wrap socket send/recv methods to count bytes.
+
+    Idempotent - later calls are no-ops. Wraps the ``socket.socket``
+    class, so it affects every socket in the process; call it once
+    during startup before the application opens its sockets.
+
+    The counter increments hold a lock. This runs on every socket
+    operation, but the work is a single integer addition, negligible
+    next to the syscall it accompanies.
+    """
+    global _installed  # noqa: PLW0603
+    if _installed:
+        return
+    _installed = True
+
+    orig_send = socket.socket.send
+    orig_sendall = socket.socket.sendall
+    orig_sendto = socket.socket.sendto
+    orig_recv = socket.socket.recv
+    orig_recv_into = socket.socket.recv_into
+    orig_recvfrom = socket.socket.recvfrom
+
+    def send(self, data, *args, **kwargs):  # noqa: ANN001, ANN202, ANN002, ANN003
+        count = orig_send(self, data, *args, **kwargs)
+        _add_sent(count)
+        return count
+
+    def sendall(self, data, *args, **kwargs):  # noqa: ANN001, ANN202, ANN002, ANN003
+        orig_sendall(self, data, *args, **kwargs)
+        _add_sent(_buflen(data))
+
+    def sendto(self, data, *args, **kwargs):  # noqa: ANN001, ANN202, ANN002, ANN003
+        count = orig_sendto(self, data, *args, **kwargs)
+        _add_sent(count)
+        return count
+
+    def recv(self, *args, **kwargs):  # noqa: ANN001, ANN202, ANN002, ANN003
+        data = orig_recv(self, *args, **kwargs)
+        _add_received(len(data))
+        return data
+
+    def recv_into(self, *args, **kwargs):  # noqa: ANN001, ANN202, ANN002, ANN003
+        count = orig_recv_into(self, *args, **kwargs)
+        _add_received(count)
+        return count
+
+    def recvfrom(self, *args, **kwargs):  # noqa: ANN001, ANN202, ANN002, ANN003
+        data, address = orig_recvfrom(self, *args, **kwargs)
+        _add_received(len(data))
+        return data, address
+
+    socket.socket.send = send  # type: ignore[method-assign]
+    socket.socket.sendall = sendall  # type: ignore[method-assign]
+    socket.socket.sendto = sendto  # type: ignore[method-assign]
+    socket.socket.recv = recv  # type: ignore[method-assign]
+    socket.socket.recv_into = recv_into  # type: ignore[method-assign]
+    socket.socket.recvfrom = recvfrom  # type: ignore[method-assign]

--- a/eventum/utils/tests/test_net_accounting.py
+++ b/eventum/utils/tests/test_net_accounting.py
@@ -1,0 +1,51 @@
+"""Tests for in-process network byte accounting."""
+
+import socket
+
+from eventum.utils import net_accounting
+
+
+def test_counts_sent_and_received_bytes() -> None:
+    """Wrapped sockets count bytes sent and received."""
+    net_accounting.install()
+    sender, receiver = socket.socketpair()
+    try:
+        before_sent = net_accounting.bytes_sent()
+        before_received = net_accounting.bytes_received()
+
+        payload = b'eventum' * 1000
+        sender.sendall(payload)
+
+        received = b''
+        while len(received) < len(payload):
+            chunk = receiver.recv(4096)
+            if not chunk:
+                break
+            received += chunk
+
+        assert received == payload
+        assert net_accounting.bytes_sent() - before_sent >= len(payload)
+        assert net_accounting.bytes_received() - before_received >= len(
+            payload
+        )
+    finally:
+        sender.close()
+        receiver.close()
+
+
+def test_install_is_idempotent() -> None:
+    """A second install does not double-count bytes."""
+    net_accounting.install()
+    net_accounting.install()
+
+    sender, receiver = socket.socketpair()
+    try:
+        before = net_accounting.bytes_sent()
+        sent = sender.send(b'x' * 64)
+        receiver.recv(sent)
+
+        # Counted once despite the double install (not double-wrapped).
+        assert net_accounting.bytes_sent() - before == sent
+    finally:
+        sender.close()
+        receiver.close()


### PR DESCRIPTION
## What

Report the Monitoring **Performance** network and disk metrics for the Eventum process instead of the whole host.

Previously `InstanceInfo` read `psutil.net_io_counters()` / `psutil.disk_io_counters()` — system-wide counters — so the numbers reflected all host traffic, not the application.

## How

- **Disk**: `Process().io_counters()` read/write bytes (per process).
- **Network**: psutil exposes no per-process network counter, so a small in-process shim (`utils/net_accounting.py`) wraps `socket.socket` send/recv and accumulates byte counts. Installed once at `App.start()`. Eventum's async output plugins (tcp, udp, httpx, aiokafka, clickhouse) all route through Python sockets, so the shim captures the application's real network I/O — TLS included (encrypted bytes reach the raw socket under asyncio).
- **CPU / memory** stay host-level.

Counters are cumulative since start (as before).

## Notes

- "Whole application" is literal: the network counter also includes the traffic of serving the Studio UI/API itself.
- Deployment target is Linux/Docker (asyncio selector loop), where the shim captures all async socket I/O.
- Field descriptions changed → the docs OpenAPI schema needs a regenerate (separate docs change).

## Tests

`utils/tests/test_net_accounting.py` — byte counting over a `socketpair` and install idempotency (no double-count). Full `app/` + `utils/` suites green; existing instance API tests green. ruff + mypy clean.