### PR TITLE
fix(ui): describe cron expressions in the engine's field order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - **MCP settings are now editable in the Studio Settings page** — the Server parameters section gained MCP controls (enable the HTTP server, allow write tools, mount path, allowed hosts); previously these were configurable only by editing `eventum.yml`, and saving settings from Studio silently reset any existing MCP configuration to defaults
 - **Opening a scenario with many instances no longer times out** — scenarios with several generators now open reliably; previously the page could hang and fail after about ten seconds while loading each instance's global-state usage
 - **Stopping the app no longer hangs when a log or MCP stream is open** — pressing Ctrl+C while a generator's live log view or a connected MCP client is streaming now shuts the app down in well under a second, instead of waiting out the graceful-shutdown timeout and printing cancellation errors on exit
+- **Studio describes cron expressions with seconds correctly** — the text under the cron **Expression** field read the seconds as the first field, so `35 10 * * * 3` was described as "At 35 seconds past the minute … only on Wednesday" while the generator actually fires at 10:35:03 every day. Descriptions now follow the same field order as the generator (`minute hour day month weekday second year`), the expression is validated by that same reading, and the field hint spells the order out
 
 ## 2.6.0 (2026-06-11)
 

--- a/eventum/ui/src/pages/ProjectPage/InputPluginsTab/InputPluginParams/CronInputPluginParams.tsx
+++ b/eventum/ui/src/pages/ProjectPage/InputPluginsTab/InputPluginParams/CronInputPluginParams.tsx
@@ -7,12 +7,12 @@ import {
   TextInput,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import cronstrue from 'cronstrue';
 import { zod4Resolver } from 'mantine-form-zod-resolver';
 import { FC } from 'react';
 import z from 'zod';
 
 import { VersatileDatetimeInput } from '../../VersatileDatetimeInput';
+import { describeCronExpression } from './cron-expression';
 import {
   CronInputPluginConfig,
   CronInputPluginConfigSchema,
@@ -24,17 +24,11 @@ interface CronInputPluginParamsProps {
   onChange: (config: CronInputPluginConfig) => void;
 }
 
-const CronExpressionSchema = z.string().refine(
-  (value) => {
-    try {
-      cronstrue.toString(value);
-      return true;
-    } catch {
-      return false;
-    }
-  },
-  { message: 'Invalid cron expression' }
-);
+const CronExpressionSchema = z
+  .string()
+  .refine((value) => describeCronExpression(value) !== null, {
+    message: 'Invalid cron expression',
+  });
 
 const ExtendedCronInputPluginConfigSchema = CronInputPluginConfigSchema.extend({
   expression: CronExpressionSchema,
@@ -52,12 +46,7 @@ export const CronInputPluginParams: FC<CronInputPluginParamsProps> = ({
     validateInputOnChange: true,
   });
 
-  let cronDescription = '';
-  try {
-    cronDescription = cronstrue.toString(form.values.expression);
-  } catch {
-    /* empty */
-  }
+  const cronDescription = describeCronExpression(form.values.expression) ?? '';
 
   return (
     <Stack gap="xs">
@@ -67,8 +56,7 @@ export const CronInputPluginParams: FC<CronInputPluginParamsProps> = ({
             label={
               <LabelWithTooltip
                 label="Expression"
-                tooltip="Cron expression (supports specifying seconds, years, random
-        values and keywords)"
+                tooltip="Cron expression in minute hour day month weekday order, with optional second and year fields placed after weekday (random values and keywords are supported)"
               />
             }
             required

--- a/eventum/ui/src/pages/ProjectPage/InputPluginsTab/InputPluginParams/cron-expression.ts
+++ b/eventum/ui/src/pages/ProjectPage/InputPluginsTab/InputPluginParams/cron-expression.ts
@@ -1,0 +1,35 @@
+import cronstrue from 'cronstrue';
+
+/**
+ * Translate an expression from the engine's field order into the one
+ * cronstrue expects.
+ *
+ * The engine (croniter) puts seconds last - `minute hour day month weekday
+ * [second] [year]` - while cronstrue puts them first - `[second] minute hour
+ * day month weekday [year]`. Without the swap a 6- or 7-field expression is
+ * described as a completely different schedule.
+ *
+ * Anything that is not 6 or 7 fields (a plain 5-field expression, a `@daily`
+ * keyword, an unfinished input) needs no swap and is passed through as is.
+ */
+function toCronstrueOrder(expression: string): string {
+  const fields = expression.trim().split(/\s+/);
+
+  if (fields.length !== 6 && fields.length !== 7) {
+    return expression;
+  }
+
+  return [fields[5], ...fields.slice(0, 5), ...fields.slice(6)].join(' ');
+}
+
+/**
+ * Describe a cron expression in human-readable form, returning `null` when
+ * the expression cannot be parsed.
+ */
+export function describeCronExpression(expression: string): string | null {
+  try {
+    return cronstrue.toString(toCronstrueOrder(expression));
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Fixes #182.

Studio described a cron expression with a seconds field as if seconds came first, while the generator reads them after weekday. `35 10 * * * 3` was labelled "At 35 seconds past the minute, at 10 minutes past the hour, only on Wednesday"; it actually fires at 10:35:03 every day.

## Changes

- `cron-expression.ts` (new) - moves the seconds field to the front for 6- and 7-field expressions before handing them to cronstrue, and returns `null` when the expression cannot be described. Five-field expressions, `@daily`-style keywords and unfinished input pass through untouched.
- `CronInputPluginParams.tsx` - the description under the field and the `Invalid cron expression` check now share that one path, so they can no longer disagree. The field hint spells out the order: `minute hour day month weekday`, with optional second and year after weekday.
- Changelog entry.

## Verification

Behaviour compared against croniter, the parser the plugin uses:

| Expression | Engine | Description |
|---|---|---|
| `35 10 * * * 3` | 10:35:03 daily | At 10:35:03 AM |
| `*/5 * * * * *` | every second in minutes divisible by 5 | Every second, every 5 minutes |
| `35 10 * * * 3 2027` | 10:35:03 daily in 2027 | At 10:35:03 AM, only in 2027 |
| `35 10 * * *` | 10:35 daily | At 10:35 AM |
| `0 0 1 1 * 2027` | rejected | no description, field invalid |

`pnpm build`, `pnpm lint`, Prettier, `ruff check`, `ruff format --check` and `mypy` are green.

## Related

- eventum-generator/docs#46 corrects the field-order table in the cron reference.
- #187 tracks the docs examples written under the same misconception.
- #185 tracks the remaining cronstrue/croniter validation gaps (`R`, parameter placeholders).
