### PR TITLE
fix: size Studio request deadlines and stream generator files as snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 
 #### MCP
 
+- **Capped what one file read hands to the agent** — `read_generator_file` returned the whole file, so an output file or a large sample went into the agent's context in one piece. A call now returns at most 64 KB, 256 KB on request, ending on a complete line, and reports the file size together with the offset to continue from - an agent pages through a large file instead of pulling it whole
 - **Widened the guidance given to agents** — large CSV/JSON samples go through the REST file API (over HTTP) or straight to disk (locally) instead of the slow `write_generator_file` tool. The agent is also told that templates can import any installed Python package and run shell commands via `subprocess`, that the server exposes an OpenAPI schema to fall back on when no tool fits, and how live/sample modes and scenarios work
 
 #### API/CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ All notable changes to this project will be documented in this file.
 
 #### MCP
 
-- **Capped what one file read hands to the agent** — `read_generator_file` returned the whole file, so an output file or a large sample went into the agent's context in one piece. A call now returns at most 64 KB, 256 KB on request, ending on a complete line, and reports the file size together with the offset to continue from - an agent pages through a large file instead of pulling it whole
+- **Bounded what file access hands to the agent** — `read_generator_file` returned the whole file, so an output file or a large sample went into the agent's context in one piece. A call now returns at most 64 KB, 256 KB when asked for, ending on a complete line, and reports the file size with the offset to continue from, so an agent pages through anything larger. `describe_sample` parses a sample whole, the way a run loads it, so it now refuses a file above 32 MB and points at the windowed read instead. The authoring prompt tells the agent how to page a read
 - **Widened the guidance given to agents** — large CSV/JSON samples go through the REST file API (over HTTP) or straight to disk (locally) instead of the slow `write_generator_file` tool. The agent is also told that templates can import any installed Python package and run shell commands via `subprocess`, that the server exposes an OpenAPI schema to fall back on when no tool fits, and how live/sample modes and scenarios work
 
 #### API/CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - **Added an unsaved-changes guard** — leaving an instance or a project with unsaved changes asks for confirmation on any navigation and warns before a refresh or a closed tab; previously only the back button was covered
 - **Added a Clone action to the instance row menu** — creates a new instance from an existing one, reusing its project and all parameters
 - **Made Studio navigation link-based** — record names, sidebar items, breadcrumbs, home cards and in-page links are real links, so middle-click and Ctrl/Cmd-click open them in a new browser tab; middle-click also closes an editor tab. Selecting a record name no longer opens it, so names stay copyable
+- **Added file sizes to the project file tree** — every file shows its size next to its name, and a file over 10 MB is not opened in the editor: the tab reports the size and the limit instead of transferring a file the editor cannot display. Generator output files are the usual case
 
 #### MCP
 
@@ -27,6 +28,7 @@ All notable changes to this project will be documented in this file.
 
 #### Eventum Studio
 
+- **Gave file transfers their own request deadline** — every request from Studio shared a single 10-second deadline, so opening or uploading a large project file failed while the transfer was still running. Requests that carry file content now run without a deadline and the rest have 60 seconds; a request that does run out of time says so instead of reporting a generic failure
 - **Added MCP controls to the Server settings section** — the HTTP server toggle, write-tool permission, mount path and allowed hosts are now editable in Studio; previously they lived only in `eventum.yml`, and saving settings from Studio reset them to defaults
 - **Cleared the cached project configuration on delete and create** — a project created with the name of a deleted one starts from a clean configuration instead of showing the old project's settings
 - **Restricted the Write timeout field to whole seconds** — it accepted fractional values that the configuration then rejected on save
@@ -43,6 +45,7 @@ All notable changes to this project will be documented in this file.
 
 #### API/CLI
 
+- **Served a generator file as a snapshot of the moment it was requested** — reading an output file of a running generator aborted mid-response, because the response declared the file size before reading the file and the file kept growing. A file that cannot be read now answers with an error instead of a dropped connection
 - **Moved the scenario global-state scan to a worker thread** — a scenario with many generators opens instead of hanging and failing after about ten seconds
 
 ### 📝 Other Changes

--- a/eventum/api/routers/generator_configs/file_tree.py
+++ b/eventum/api/routers/generator_configs/file_tree.py
@@ -19,6 +19,10 @@ class FileNode(BaseModel, frozen=True, extra='forbid'):
     is_dir : bool
         Whether this node represents a directory or a file.
 
+    size_in_bytes : int | None
+        Size of the file in bytes. `None` for directories and for files
+        whose size cannot be read.
+
     children : list[FileNode] | None
         Nested file nodes if this node is a directory. `None` if this
         node is a file.
@@ -27,6 +31,7 @@ class FileNode(BaseModel, frozen=True, extra='forbid'):
 
     name: str
     is_dir: bool
+    size_in_bytes: int | None = None  # only for files
     children: list[FileNode] | None = None  # only for directories
 
 
@@ -56,4 +61,22 @@ def build_file_tree(path: Path) -> FileNode:
             is_dir=True,
             children=[build_file_tree(child) for child in path.iterdir()],
         )
-    return FileNode(name=path.name, is_dir=False)
+
+    return FileNode(
+        name=path.name,
+        is_dir=False,
+        size_in_bytes=_get_file_size(path),
+    )
+
+
+def _get_file_size(path: Path) -> int | None:
+    """Get file size in bytes, or `None` if it cannot be read.
+
+    Size of a file that cannot be stat'ed - a broken symlink, for
+    example - is reported as unknown, so that a single such entry does
+    not fail the whole tree.
+    """
+    try:
+        return path.stat().st_size
+    except OSError:
+        return None

--- a/eventum/api/routers/generator_configs/routes.py
+++ b/eventum/api/routers/generator_configs/routes.py
@@ -40,6 +40,7 @@ from eventum.api.routers.generator_configs.file_tree import (
 from eventum.api.routers.generator_configs.models import (
     GeneratorDirExtendedInfo,
 )
+from eventum.api.utils.file_streaming import stream_snapshot
 from eventum.api.utils.response_description import merge_responses
 from eventum.utils.dotted_keys import DottedKeyError, expand_dotted_keys
 from eventum.utils.fs_utils import (
@@ -423,7 +424,7 @@ async def get_generator_file(
         Annotated[Path, CheckFilepathIsDirectlyRelativeDep],
     ],
     settings: SettingsDep,
-) -> responses.FileResponse:
+) -> responses.StreamingResponse:
     path = (settings.path.generators_dir / name / filepath).resolve()
 
     if not path.is_file():
@@ -432,13 +433,24 @@ async def get_generator_file(
             detail='File does not exist',
         )
 
+    # File is opened here, before the response starts, so that an
+    # unreadable file is reported as an error instead of aborting the
+    # connection in the middle of the body.
     try:
-        return responses.FileResponse(path=path, media_type='text/plain')
+        file = await aiofiles.open(path, 'rb')
     except OSError as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f'File cannot be read due to OS error: {e}',
         ) from None
+
+    # Content length is intentionally left undeclared: a generator
+    # writing to the file changes its size at any moment, and a declared
+    # length would stop matching the sent body.
+    return responses.StreamingResponse(
+        stream_snapshot(file),
+        media_type='text/plain',
+    )
 
 
 @router.post(

--- a/eventum/api/tests/test_file_tree.py
+++ b/eventum/api/tests/test_file_tree.py
@@ -62,3 +62,30 @@ def test_node_names_match_path(tmp_path):
 
     node = build_file_tree(f)
     assert node.name == 'my_file.yml'
+
+
+def test_file_size(tmp_path):
+    f = tmp_path / 'test.txt'
+    f.write_bytes(b'content')
+
+    node = build_file_tree(f)
+    assert node.size_in_bytes == len(b'content')
+
+
+def test_directory_size_is_unknown(tmp_path):
+    d = tmp_path / 'project'
+    d.mkdir()
+    (d / 'test.txt').write_bytes(b'content')
+
+    node = build_file_tree(d)
+    assert node.size_in_bytes is None
+    assert node.children[0].size_in_bytes == len(b'content')  # type: ignore
+
+
+def test_unreadable_file_size_is_unknown(tmp_path):
+    link = tmp_path / 'dangling.txt'
+    link.symlink_to(tmp_path / 'missing.txt')
+
+    node = build_file_tree(link)
+    assert node.is_dir is False
+    assert node.size_in_bytes is None

--- a/eventum/api/tests/test_generator_configs.py
+++ b/eventum/api/tests/test_generator_configs.py
@@ -1,5 +1,6 @@
 """Tests for generator configs API router."""
 
+import aiofiles
 import pytest
 import yaml
 from fastapi import FastAPI
@@ -321,6 +322,63 @@ def test_get_file_tree(client, tmp_settings):
     names = {node['name'] for node in data}
     assert tmp_settings.path.generator_config_filename.name in names
     assert 'templates' in names
+
+
+def test_get_file_tree_reports_sizes(client, tmp_settings):
+    gen_dir = _create_config(tmp_settings, 'size_gen')
+    (gen_dir / 'sample.csv').write_bytes(b'a,b,c')
+
+    response = client.get('/configs/size_gen/file-tree')
+    assert response.status_code == 200
+
+    nodes = {node['name']: node for node in response.json()}
+    assert nodes['sample.csv']['size_in_bytes'] == len(b'a,b,c')
+
+
+# --- GET /{name}/file/{filepath} ---
+
+
+def test_get_file(client, tmp_settings):
+    gen_dir = _create_config(tmp_settings, 'read_gen')
+    (gen_dir / 'notes.txt').write_text('file content')
+
+    response = client.get('/configs/read_gen/file/notes.txt')
+    assert response.status_code == 200
+    assert response.text == 'file content'
+    assert response.headers['content-type'] == 'text/plain; charset=utf-8'
+
+
+def test_get_file_declares_no_length(client, tmp_settings):
+    # A file a generator is writing to changes its size at any moment,
+    # so a declared length stops matching the body being sent and the
+    # response is aborted mid-body.
+    gen_dir = _create_config(tmp_settings, 'length_gen')
+    (gen_dir / 'output.ndjson').write_text('{"a": 1}\n')
+
+    response = client.get('/configs/length_gen/file/output.ndjson')
+    assert response.status_code == 200
+    assert 'content-length' not in response.headers
+
+
+def test_get_file_not_found(client, tmp_settings):
+    _create_config(tmp_settings, 'missing_file_gen')
+
+    response = client.get('/configs/missing_file_gen/file/absent.txt')
+    assert response.status_code == 404
+
+
+def test_get_file_os_error(client, tmp_settings, monkeypatch):
+    gen_dir = _create_config(tmp_settings, 'error_gen')
+    (gen_dir / 'notes.txt').write_text('file content')
+
+    def raise_os_error(*args, **kwargs):
+        raise OSError('permission denied')
+
+    monkeypatch.setattr(aiofiles, 'open', raise_os_error)
+
+    response = client.get('/configs/error_gen/file/notes.txt')
+    assert response.status_code == 500
+    assert 'OS error' in response.json()['detail']
 
 
 # --- Directory traversal ---

--- a/eventum/api/utils/file_streaming.py
+++ b/eventum/api/utils/file_streaming.py
@@ -3,12 +3,58 @@
 import asyncio
 import contextlib
 import os
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator
 from pathlib import Path
 
 import aiofiles
+from aiofiles.threadpool.binary import AsyncBufferedReader
 
 _IDLE_POLL_INTERVAL = 0.5
+_SNAPSHOT_CHUNK_SIZE = 64 * 1024
+
+
+async def stream_snapshot(
+    file: AsyncBufferedReader,
+) -> AsyncGenerator[bytes]:
+    """Stream file content as it is at the beginning of the call.
+
+    Reads at most as many bytes as the file holds when the streaming
+    starts, so content appended by a concurrent writer is left out and
+    the stream is guaranteed to end. A file truncated mid-read ends the
+    stream early. The file is closed once the stream is over or
+    abandoned.
+
+    Parameters
+    ----------
+    file : AsyncBufferedReader
+        Opened file to stream. Ownership is transferred to this call.
+
+    Yields
+    ------
+    bytes
+        File chunk.
+
+    Raises
+    ------
+    OSError
+        If file cannot be read.
+
+    """
+    try:
+        await file.seek(0, os.SEEK_END)
+        remaining = await file.tell()
+        await file.seek(0, os.SEEK_SET)
+
+        while remaining > 0:
+            chunk = await file.read(min(_SNAPSHOT_CHUNK_SIZE, remaining))
+
+            if not chunk:
+                break
+
+            remaining -= len(chunk)
+            yield chunk
+    finally:
+        await file.close()
 
 
 async def stream_file(

--- a/eventum/api/utils/tests/test_file_streaming.py
+++ b/eventum/api/utils/tests/test_file_streaming.py
@@ -3,7 +3,97 @@
 import asyncio
 from pathlib import Path
 
-from eventum.api.utils.file_streaming import stream_file
+import aiofiles
+
+from eventum.api.utils.file_streaming import (
+    _SNAPSHOT_CHUNK_SIZE,
+    stream_file,
+    stream_snapshot,
+)
+
+
+async def test_snapshot_streams_whole_file(tmp_path: Path) -> None:
+    """Content of the file is streamed and the file is closed."""
+    target = tmp_path / 'data.txt'
+    target.write_bytes(b'hello world')
+    file = await aiofiles.open(target, 'rb')
+
+    chunks = [chunk async for chunk in stream_snapshot(file)]
+
+    assert b''.join(chunks) == b'hello world'
+    assert file.closed
+
+
+async def test_snapshot_streams_empty_file(tmp_path: Path) -> None:
+    """An empty file yields nothing."""
+    target = tmp_path / 'data.txt'
+    target.write_bytes(b'')
+    file = await aiofiles.open(target, 'rb')
+
+    chunks = [chunk async for chunk in stream_snapshot(file)]
+
+    assert chunks == []
+    assert file.closed
+
+
+async def test_snapshot_excludes_appended_content(tmp_path: Path) -> None:
+    """Content appended while streaming is left out of the stream.
+
+    This is the regression guard: the response used to declare the file
+    size up front and then stream everything the file held, so a
+    generator appending to the file broke the response in the middle of
+    the body.
+    """
+    target = tmp_path / 'data.txt'
+    original = b'a' * (_SNAPSHOT_CHUNK_SIZE * 2)
+    target.write_bytes(original)
+    file = await aiofiles.open(target, 'rb')
+
+    stream = stream_snapshot(file)
+    chunks = [await anext(stream)]
+
+    with target.open('ab') as f:
+        f.write(b'b' * _SNAPSHOT_CHUNK_SIZE)
+
+    chunks.extend([chunk async for chunk in stream])
+
+    assert b''.join(chunks) == original
+
+
+async def test_snapshot_ends_on_truncated_file(tmp_path: Path) -> None:
+    """Truncation while streaming ends the stream on the read content.
+
+    How much of the file is already read at the moment of truncation
+    depends on the buffering, so only the invariant is asserted: the
+    stream ends, and what it yields is a prefix of the original content.
+    """
+    target = tmp_path / 'data.txt'
+    original = bytes(range(256)) * (_SNAPSHOT_CHUNK_SIZE * 3 // 256)
+    target.write_bytes(original)
+    file = await aiofiles.open(target, 'rb')
+
+    stream = stream_snapshot(file)
+    chunks = [await anext(stream)]
+
+    target.write_bytes(b'')
+
+    chunks.extend([chunk async for chunk in stream])
+
+    assert original.startswith(b''.join(chunks))
+    assert file.closed
+
+
+async def test_snapshot_closes_abandoned_file(tmp_path: Path) -> None:
+    """An abandoned stream closes the file it owns."""
+    target = tmp_path / 'data.txt'
+    target.write_bytes(b'a' * (_SNAPSHOT_CHUNK_SIZE * 2))
+    file = await aiofiles.open(target, 'rb')
+
+    stream = stream_snapshot(file)
+    await anext(stream)
+    await stream.aclose()
+
+    assert file.closed
 
 
 async def test_streams_existing_tail(tmp_path: Path) -> None:

--- a/eventum/app/tests/test_workspace.py
+++ b/eventum/app/tests/test_workspace.py
@@ -11,6 +11,7 @@ from eventum.app.workspace import (
     delete_file,
     ensure_relative,
     read_text,
+    read_text_window,
     resolve_generator_dir,
     resolve_generator_file,
     write_text,
@@ -175,4 +176,102 @@ def test_delete_dir_missing_raises(tmp_path: Path):
     missing = tmp_path / 'nope'
     with pytest.raises(WorkspaceError) as exc_info:
         delete_dir(missing)
+    assert exc_info.value.context['file_path'] == str(missing)
+
+
+def test_window_holds_whole_small_file(tmp_path: Path) -> None:
+    """A file inside the limit comes back with nothing to continue."""
+    target = tmp_path / 'sample.csv'
+    target.write_text('host,role\nweb-01,frontend\n')
+
+    window = read_text_window(target, offset=0, limit=1024)
+
+    assert window.content == 'host,role\nweb-01,frontend\n'
+    assert window.offset == 0
+    assert window.next_offset is None
+    assert window.size_in_bytes == target.stat().st_size
+
+
+def test_window_ends_on_a_complete_line(tmp_path: Path) -> None:
+    """A window cut mid-line is trimmed back to the last line break."""
+    target = tmp_path / 'events.json'
+    target.write_text('aaaa\nbbbb\ncccc\n')
+
+    window = read_text_window(target, offset=0, limit=12)
+
+    assert window.content == 'aaaa\nbbbb\n'
+    assert window.next_offset == 10
+
+
+def test_windows_page_the_whole_file(tmp_path: Path) -> None:
+    """Following next_offset reads every byte exactly once."""
+    target = tmp_path / 'events.json'
+    content = ''.join(f'line {i}\n' for i in range(500))
+    target.write_text(content)
+
+    pages: list[str] = []
+    offset: int | None = 0
+
+    while offset is not None:
+        window = read_text_window(target, offset=offset, limit=64)
+        pages.append(window.content)
+        offset = window.next_offset
+
+    assert ''.join(pages) == content
+
+
+def test_window_keeps_an_oversized_line(tmp_path: Path) -> None:
+    """A window without a line break is returned as it is.
+
+    A minified JSON file is one long line; trimming it to a line break
+    would yield nothing and the read would never advance.
+    """
+    target = tmp_path / 'events.json'
+    target.write_text('x' * 100)
+
+    window = read_text_window(target, offset=0, limit=10)
+
+    assert window.content == 'x' * 10
+    assert window.next_offset == 10
+
+
+def test_window_past_the_end_is_empty(tmp_path: Path) -> None:
+    """An offset beyond the file yields an empty final window."""
+    target = tmp_path / 'sample.csv'
+    target.write_text('host\n')
+
+    window = read_text_window(target, offset=999, limit=64)
+
+    assert window.content == ''
+    assert window.offset == window.size_in_bytes
+    assert window.next_offset is None
+
+
+def test_window_advances_on_a_non_positive_limit(tmp_path: Path) -> None:
+    """A limit below one still reads a byte instead of standing still."""
+    target = tmp_path / 'sample.csv'
+    target.write_text('abc')
+
+    window = read_text_window(target, offset=0, limit=0)
+
+    assert window.content == 'a'
+    assert window.next_offset == 1
+
+
+def test_window_replaces_undecodable_bytes(tmp_path: Path) -> None:
+    """A window starting inside a character does not fail the read."""
+    target = tmp_path / 'sample.csv'
+    target.write_bytes(b'h\xc3\xa9llo')
+
+    window = read_text_window(target, offset=2, limit=64)
+
+    assert window.content == '�llo'
+    assert window.next_offset is None
+
+
+def test_window_of_missing_file_raises(tmp_path: Path) -> None:
+    """A missing file is reported as a workspace error."""
+    missing = tmp_path / 'absent.csv'
+    with pytest.raises(WorkspaceError) as exc_info:
+        read_text_window(missing, offset=0, limit=64)
     assert exc_info.value.context['file_path'] == str(missing)

--- a/eventum/app/workspace.py
+++ b/eventum/app/workspace.py
@@ -6,8 +6,11 @@ adapters. No transport concerns here.
 
 import shutil
 from pathlib import Path
+from typing import NamedTuple
 
 from eventum.exceptions import ContextualError
+
+_LINE_BREAK = b'\n'
 
 
 class WorkspaceError(ContextualError):
@@ -144,6 +147,97 @@ def read_text(path: Path) -> str:
             msg,
             context={'reason': str(e), 'file_path': str(path)},
         ) from None
+
+
+class TextWindow(NamedTuple):
+    """Bounded window of a text file.
+
+    Attributes
+    ----------
+    content : str
+        Content of the window.
+
+    offset : int
+        Byte offset the window starts at.
+
+    next_offset : int | None
+        Byte offset to continue reading from, or `None` when the window
+        reaches the end of the file.
+
+    size_in_bytes : int
+        Size of the whole file.
+
+    """
+
+    content: str
+    offset: int
+    next_offset: int | None
+    size_in_bytes: int
+
+
+def read_text_window(path: Path, offset: int, limit: int) -> TextWindow:
+    """Read at most `limit` bytes of a text file, starting at `offset`.
+
+    A window that stops short of the end of the file is cut back to its
+    last complete line, so consecutive windows never split a line. A
+    window holding no line break at all is returned as it is, which
+    keeps a single oversized line readable and every window advancing.
+
+    Undecodable bytes are replaced instead of failing the read - a
+    window may begin or end inside a multi-byte character.
+
+    Parameters
+    ----------
+    path : Path
+        Path to read.
+
+    offset : int
+        Byte offset to start at. Clamped to the file bounds.
+
+    limit : int
+        Maximum number of bytes to read. Values below one are read as
+        one, so a window always advances.
+
+    Returns
+    -------
+    TextWindow
+        Window content with the offsets needed to continue.
+
+    Raises
+    ------
+    WorkspaceError
+        If the file cannot be read.
+
+    """
+    try:
+        size = path.stat().st_size
+
+        with path.open('rb') as f:
+            f.seek(min(max(offset, 0), size))
+            start = f.tell()
+            data = f.read(max(limit, 1))
+    except OSError as e:
+        msg = 'Failed to read file'
+        raise WorkspaceError(
+            msg,
+            context={'reason': str(e), 'file_path': str(path)},
+        ) from None
+
+    end = start + len(data)
+
+    if end < size:
+        last_line_end = data.rfind(_LINE_BREAK) + 1
+
+        if last_line_end > 0:
+            data = data[:last_line_end]
+            end = start + last_line_end
+
+    return TextWindow(
+        content=data.decode('utf-8', errors='replace'),
+        offset=start,
+        next_offset=end if end < size else None,
+        size_in_bytes=size,
+    )
 
 
 def write_text(path: Path, content: str) -> None:

--- a/eventum/mcp/prompts/authoring.py
+++ b/eventum/mcp/prompts/authoring.py
@@ -34,7 +34,11 @@ when you validate, preview, or run.
 3. For a `template` event plugin, match technique to intent: a picking \
 mode (`all`/`chance`/`spin`/`chain`/`fsm`) for several variants or a \
 stateful sequence, and `shared`/`locals` state for correlated or \
-drifting values. Inspect any data files with `describe_sample`.
+drifting values. Inspect any data files with `describe_sample` - it \
+summarises a sample without pulling it into the conversation, and \
+`read_generator_file` returns one window of a file at a time, so \
+continue from its `next_offset` while `truncated` is true instead of \
+expecting a whole file back.
 4. Write the file set with `write_generator_file`, paths relative to \
 the generator directory: `generator.yml`, plus `templates/` and \
 `samples/` for a template generator. A `replay` generator just points \

--- a/eventum/mcp/tests/test_prompts.py
+++ b/eventum/mcp/tests/test_prompts.py
@@ -47,6 +47,13 @@ def test_create_generator_surfaces_module_and_large_sample() -> None:
     assert '/api/generator-configs/' in text
 
 
+def test_create_generator_explains_windowed_reads() -> None:
+    """The prompt tells the agent to page a file read."""
+    text = create_generator_text()
+    assert 'next_offset' in text
+    assert 'truncated' in text
+
+
 def test_live_ops_covers_modes_and_scenarios() -> None:
     """The live-ops prompt explains run modes and scenarios."""
     text = live_ops_text()

--- a/eventum/mcp/tests/test_samples.py
+++ b/eventum/mcp/tests/test_samples.py
@@ -49,6 +49,32 @@ async def test_describe_sample_csv(ctx: FileAuthoringContext) -> None:
     assert result['example_rows'] == [['Paris', 'FR'], ['Lyon', 'FR']]
 
 
+async def test_describe_sample_refuses_an_oversized_file(
+    ctx: FileAuthoringContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A file over the ceiling is refused instead of being parsed.
+
+    This is the regression guard: the whole file used to be parsed to
+    count its rows, so pointing the tool at an output file of a long run
+    loaded it into memory.
+    """
+    content = 'city,country\nParis,FR\nLyon,FR\n'
+    ceiling = len(content) - 1
+    monkeypatch.setattr('eventum.mcp.tools.samples._MAX_SAMPLE_BYTES', ceiling)
+    name = _make_gen(ctx, content)
+
+    result = await describe_sample(
+        ctx, name=name, relative_path='samples/data.csv'
+    )
+
+    assert isinstance(result, ToolFailure)
+    assert result.error == 'Sample file is too large to introspect'
+    assert result.details['size_in_bytes'] == len(content)
+    assert result.details['max_size_in_bytes'] == ceiling
+    assert 'read_generator_file' in result.details['hint']
+
+
 async def test_describe_sample_traversal_rejected(
     ctx: FileAuthoringContext,
 ) -> None:

--- a/eventum/mcp/tests/test_workspace_files.py
+++ b/eventum/mcp/tests/test_workspace_files.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from eventum.mcp.context import FileAuthoringContext
 from eventum.mcp.errors import ToolFailure
 from eventum.mcp.tools.workspace_files import (
+    _MAX_READ_BYTES,
     delete_generator,
     delete_generator_file,
     list_generator_files,
@@ -12,6 +13,9 @@ from eventum.mcp.tools.workspace_files import (
     read_generator_file,
     write_generator_file,
 )
+
+# Small enough to page a test file in a handful of windows.
+_LINE_LIMIT = 256
 
 
 def _ctx(tmp_path: Path, *, read_only: bool = False) -> FileAuthoringContext:
@@ -63,10 +67,92 @@ def test_list_generator_files_unknown(tmp_path: Path) -> None:
 
 
 def test_read_generator_file(tmp_path: Path) -> None:
-    """Known file contents are returned verbatim."""
+    """A file within the window is returned whole and not truncated."""
     _gen(tmp_path)
     result = read_generator_file(_ctx(tmp_path), 'g', 'templates/a.jinja')
-    assert result == 'hi'
+    assert result == {
+        'content': 'hi',
+        'offset': 0,
+        'next_offset': None,
+        'size_in_bytes': 2,
+        'truncated': False,
+    }
+
+
+def test_read_generator_file_windows_large_file(tmp_path: Path) -> None:
+    """A file over the limit is windowed and reports what is left.
+
+    This is the regression guard: the whole file used to be returned, so
+    an output file or a large sample landed in the agent's context in
+    one piece.
+    """
+    d = _gen(tmp_path)
+    lines = [f'{{"n": {i}}}\n' for i in range(400)]
+    (d / 'big.json').write_text(''.join(lines))
+
+    result = read_generator_file(
+        _ctx(tmp_path), 'g', 'big.json', limit=_LINE_LIMIT
+    )
+
+    assert not isinstance(result, ToolFailure)
+    assert result['truncated'] is True
+    assert result['offset'] == 0
+    assert result['size_in_bytes'] == len(''.join(lines))
+    assert len(result['content'].encode()) <= _LINE_LIMIT
+    # Windows end on a line break, so a page is never a partial line.
+    assert result['content'].endswith('\n')
+    assert result['next_offset'] == len(result['content'].encode())
+
+
+def test_read_generator_file_pages_whole_file(tmp_path: Path) -> None:
+    """Following next_offset reads the file without gaps or repeats."""
+    d = _gen(tmp_path)
+    content = ''.join(f'{{"n": {i}}}\n' for i in range(400))
+    (d / 'big.json').write_text(content)
+
+    pages: list[str] = []
+    offset: int | None = 0
+
+    while offset is not None:
+        page = read_generator_file(
+            _ctx(tmp_path), 'g', 'big.json', offset=offset, limit=_LINE_LIMIT
+        )
+        assert not isinstance(page, ToolFailure)
+        pages.append(page['content'])
+        offset = page['next_offset']
+
+    assert ''.join(pages) == content
+
+
+def test_read_generator_file_caps_limit(tmp_path: Path) -> None:
+    """A limit above the cap is clamped instead of honoured."""
+    d = _gen(tmp_path)
+    content = 'x' * (_MAX_READ_BYTES * 2)
+    (d / 'big.csv').write_text(content)
+
+    result = read_generator_file(
+        _ctx(tmp_path), 'g', 'big.csv', limit=_MAX_READ_BYTES * 2
+    )
+
+    assert not isinstance(result, ToolFailure)
+    assert len(result['content']) == _MAX_READ_BYTES
+    assert result['truncated'] is True
+
+
+def test_read_generator_file_offset_past_end(tmp_path: Path) -> None:
+    """An offset past the end of the file yields nothing to continue."""
+    _gen(tmp_path)
+    result = read_generator_file(
+        _ctx(tmp_path), 'g', 'templates/a.jinja', offset=1000
+    )
+
+    assert result == {
+        'content': '',
+        'offset': 2,
+        'next_offset': None,
+        'size_in_bytes': 2,
+        'truncated': False,
+    }
 
 
 def test_read_generator_file_not_found(tmp_path: Path) -> None:
@@ -110,9 +196,10 @@ def test_write_generator_file_roundtrip(tmp_path: Path) -> None:
     _gen(tmp_path)
     res = write_generator_file(_ctx(tmp_path), 'g', 'templates/b.jinja', 'yo')
     assert res == {'written': 'templates/b.jinja'}
-    assert (
-        read_generator_file(_ctx(tmp_path), 'g', 'templates/b.jinja') == 'yo'
-    )
+
+    read = read_generator_file(_ctx(tmp_path), 'g', 'templates/b.jinja')
+    assert not isinstance(read, ToolFailure)
+    assert read['content'] == 'yo'
 
 
 def test_write_blocked_when_read_only(tmp_path: Path) -> None:

--- a/eventum/mcp/tools/samples.py
+++ b/eventum/mcp/tools/samples.py
@@ -26,15 +26,20 @@ from eventum.plugins.event.plugins.template.sample_reader import (
 _EXAMPLE_ROWS_LIMIT = 5
 _KEY = 'sample'
 
+# Introspection parses the sample whole, the way a run loads it, so the
+# cost follows the file. The ceiling is orders of magnitude above any
+# real sample and only stops a file that is not one - an output file of
+# a long run, for instance, which an agent reads in windows instead.
+_MAX_SAMPLE_BYTES = 32 * 1024 * 1024
 
-def _describe_sample(
+
+def _resolve_sample(
     context: AuthoringContext,
-    name: str,
+    rel: Path,
     relative_path: str,
-) -> dict[str, Any] | ToolFailure:
-    """Resolve and parse the sample synchronously."""
-    rel = Path(relative_path)
-
+    name: str,
+) -> Path | ToolFailure:
+    """Resolve a sample path that is safe and small enough to parse."""
     try:
         path = workspace.resolve_generator_file(
             context.generators_dir, name, rel
@@ -47,6 +52,45 @@ def _describe_sample(
             error='Sample file not found',
             details={'file_path': relative_path},
         )
+
+    try:
+        size_in_bytes = path.stat().st_size
+    except OSError:
+        return ToolFailure(
+            error='Failed to load sample',
+            details={'file_path': relative_path},
+        )
+
+    if size_in_bytes > _MAX_SAMPLE_BYTES:
+        return ToolFailure(
+            error='Sample file is too large to introspect',
+            details={
+                'file_path': relative_path,
+                'size_in_bytes': size_in_bytes,
+                'max_size_in_bytes': _MAX_SAMPLE_BYTES,
+                'hint': (
+                    'Read the beginning of the file with '
+                    'read_generator_file instead.'
+                ),
+            },
+        )
+
+    return path
+
+
+def _describe_sample(
+    context: AuthoringContext,
+    name: str,
+    relative_path: str,
+) -> dict[str, Any] | ToolFailure:
+    """Resolve and parse the sample synchronously."""
+    rel = Path(relative_path)
+
+    resolved = _resolve_sample(context, rel, relative_path, name)
+    if isinstance(resolved, ToolFailure):
+        return resolved
+
+    path = resolved
 
     # Exact-case match: the sample config source validators accept
     # only lowercase '.csv'/'.json', mirroring the workspace file
@@ -140,8 +184,9 @@ async def describe_sample(
 
     ToolFailure
         If the path escapes the generator directory, the file does not
-        exist, the file type is unsupported, or the sample is malformed.
-        Never raises; does not leak absolute paths.
+        exist, the file type is unsupported, the file is larger than
+        the introspection ceiling, or the sample is malformed. Never
+        raises; does not leak absolute paths.
 
     """
     return await asyncio.to_thread(
@@ -167,6 +212,10 @@ def register(
         Use it to learn a sample's column names so templates can
         reference them via ``samples.<name>.pick().<column>``.
 
+        The file is parsed whole, as a run would load it, so a file
+        larger than 32 MB is refused instead - read the beginning of
+        such a file with ``read_generator_file``.
+
         Parameters
         ----------
         name : str
@@ -181,7 +230,8 @@ def register(
         dict[str, Any] | ToolFailure
             ``type``, ``columns``, ``row_count``, and ``example_rows``
             for the sample, or a structured failure if the path is
-            invalid, missing, unsupported, or malformed. Does not raise.
+            invalid, missing, unsupported, too large, or malformed. Does
+            not raise.
 
         """
         return observe_failure(

--- a/eventum/mcp/tools/workspace_files.py
+++ b/eventum/mcp/tools/workspace_files.py
@@ -26,6 +26,13 @@ from eventum.mcp.observability import observe_failure
 
 _ALLOWED_EXTENSIONS = frozenset({'.yml', '.yaml', '.jinja', '.csv', '.json'})
 
+# A generator directory holds files of any size - an output file of a
+# long run, a large sample - and a whole file would land in the agent's
+# context. Reads are windowed instead, with the same budget the log tail
+# uses, and the agent pages through anything larger.
+_DEFAULT_READ_BYTES = 64 * 1024
+_MAX_READ_BYTES = 256 * 1024
+
 
 def _check_extension(rel: Path, relative_path: str) -> ToolFailure | None:
     """Reject a path whose suffix is not in the allow-list.
@@ -122,8 +129,10 @@ def read_generator_file(
     context: AuthoringContext,
     name: str,
     relative_path: str,
-) -> str | ToolFailure:
-    """Return the text content of a file in a generator directory.
+    offset: int = 0,
+    limit: int = _DEFAULT_READ_BYTES,
+) -> dict[str, Any] | ToolFailure:
+    """Return a bounded window of a file in a generator directory.
 
     Parameters
     ----------
@@ -136,10 +145,17 @@ def read_generator_file(
     relative_path : str
         Path to the file relative to the generator directory.
 
+    offset : int, default 0
+        Byte offset to read from.
+
+    limit : int, default 65536
+        Maximum number of bytes to return, capped at 262144.
+
     Returns
     -------
-    str
-        File contents.
+    dict[str, Any]
+        Window content under `content`, with `offset`, `next_offset`,
+        `size_in_bytes` and `truncated` describing what is left.
 
     ToolFailure
         If the path escapes the generator directory, the file does not
@@ -167,9 +183,21 @@ def read_generator_file(
         )
 
     try:
-        return workspace.read_text(path)
+        window = workspace.read_text_window(
+            path,
+            offset=max(offset, 0),
+            limit=max(1, min(limit, _MAX_READ_BYTES)),
+        )
     except WorkspaceError as e:
         return to_tool_error(e, context.generators_dir)
+
+    return {
+        'content': window.content,
+        'offset': window.offset,
+        'next_offset': window.next_offset,
+        'size_in_bytes': window.size_in_bytes,
+        'truncated': window.next_offset is not None,
+    }
 
 
 def write_generator_file(
@@ -416,8 +444,17 @@ def register(
     def _read_generator_file_tool(
         name: str,
         relative_path: str,
-    ) -> str | ToolFailure:
-        """Return the text content of a file in a generator directory.
+        offset: int = 0,
+        limit: int = _DEFAULT_READ_BYTES,
+    ) -> dict[str, Any] | ToolFailure:
+        """Read a file in a generator directory, one window at a time.
+
+        A generator directory can hold files of any size - the output of
+        a long run, a large sample - so a call returns at most ``limit``
+        bytes. When ``truncated`` is true, call again with ``offset``
+        set to the returned ``next_offset`` to read the next window. A
+        window that stops short of the end of the file ends on a
+        complete line.
 
         Parameters
         ----------
@@ -428,16 +465,23 @@ def register(
             Path to the file relative to the generator directory
             (e.g. ``'templates/event.jinja'``).
 
+        offset : int, default 0
+            Byte offset to read from.
+
+        limit : int, default 65536
+            Maximum number of bytes to return, capped at 262144.
+
         Returns
         -------
-        str | ToolFailure
-            File contents, or a structured failure if the path is
-            invalid, the extension is not allowed, or the file does not
-            exist. Does not raise.
+        dict[str, Any] | ToolFailure
+            Window content under ``content``, with ``offset``,
+            ``next_offset``, ``size_in_bytes`` and ``truncated``; or a
+            structured failure if the path is invalid, the extension is
+            not allowed, or the file does not exist. Does not raise.
 
         """
         return observe_failure(
-            read_generator_file(context, name, relative_path),
+            read_generator_file(context, name, relative_path, offset, limit),
             mcp_tool='read_generator_file',
             mcp_transport=transport,
         )

--- a/eventum/ui/src/api/client.ts
+++ b/eventum/ui/src/api/client.ts
@@ -2,6 +2,18 @@ import axios, { AxiosError } from 'axios';
 
 import { APIError } from './errors';
 
+// Deadline for a regular request. Long enough for the directory walks
+// and preview runs the backend performs on request, short enough to
+// surface an unresponsive backend.
+const DEFAULT_TIMEOUT = 60_000;
+
+// Deadline for a request that transfers file content. How long such a
+// request takes is set by the size of the file and the speed of the
+// link, not by the health of the backend, so any fixed deadline would
+// cut off a transfer that is still making progress. Zero disables the
+// deadline; a broken connection still fails the request.
+export const TRANSFER_TIMEOUT = 0;
+
 export const apiClient = axios.create({
   baseURL: '/api',
   withCredentials: true,
@@ -9,8 +21,40 @@ export const apiClient = axios.create({
     Accept: 'application/json',
     'Content-Type': 'application/json',
   },
-  timeout: 10_000,
+  timeout: DEFAULT_TIMEOUT,
 });
+
+// User friendly titles of response codes that make sense to distinguish
+function describeStatusCode(statusCode: number): string {
+  if (statusCode >= 500) {
+    return 'Server error';
+  } else if (statusCode === 401) {
+    return 'Invalid credentials';
+  } else if (statusCode === 403) {
+    return 'Forbidden';
+  } else if (statusCode === 404) {
+    return 'Resource not found';
+  } else if (statusCode === 409) {
+    return 'Resource already exists';
+  } else if (statusCode === 413) {
+    return 'Content too large';
+  } else if (statusCode === 422) {
+    return 'Invalid payload';
+  } else {
+    return 'Client error';
+  }
+}
+
+// A request that never reached a response either ran out of its
+// deadline or failed on the connection - the two read differently to
+// the user.
+function describeFailedRequest(error: AxiosError): string {
+  const timedOut =
+    error.code === AxiosError.ECONNABORTED ||
+    error.code === AxiosError.ETIMEDOUT;
+
+  return timedOut ? 'Request timed out' : 'Request failed';
+}
 
 apiClient.interceptors.response.use(
   (response) => response,
@@ -19,7 +63,7 @@ apiClient.interceptors.response.use(
       if (error.response === undefined) {
         return Promise.reject(
           new APIError({
-            message: 'Request failed',
+            message: describeFailedRequest(error),
             details: error.message,
             requestConfig: error.config,
           })
@@ -27,36 +71,13 @@ apiClient.interceptors.response.use(
       }
 
       const statusCode = error.response.status;
-      const response = error.response;
-      const requestConfig = error.config;
-
-      let message: string;
-
-      // User friendly titles of response codes that make sense to distinguish
-      if (statusCode >= 500) {
-        message = 'Server error';
-      } else if (statusCode === 401) {
-        message = 'Invalid credentials';
-      } else if (statusCode === 403) {
-        message = 'Forbidden';
-      } else if (statusCode === 404) {
-        message = 'Resource not found';
-      } else if (statusCode === 409) {
-        message = 'Resource already exists';
-      } else if (statusCode === 413) {
-        message = 'Content too large';
-      } else if (statusCode === 422) {
-        message = 'Invalid payload';
-      } else {
-        message = 'Client error';
-      }
 
       return Promise.reject(
         new APIError({
-          message: message,
+          message: describeStatusCode(statusCode),
           details: `Server respond with status code ${statusCode}`,
-          response: response,
-          requestConfig: requestConfig,
+          response: error.response,
+          requestConfig: error.config,
         })
       );
     } else if (error instanceof Error) {

--- a/eventum/ui/src/api/hooks/useGeneratorConfigs.ts
+++ b/eventum/ui/src/api/hooks/useGeneratorConfigs.ts
@@ -142,10 +142,15 @@ export function useGeneratorFileTree(name: string) {
   });
 }
 
-export function useGeneratorFileContent(name: string, filepath: string) {
+export function useGeneratorFileContent(
+  name: string,
+  filepath: string,
+  options?: { enabled?: boolean }
+) {
   return useQuery({
     queryKey: [...GENERATOR_CONFIG_DIR_FILES_QUERY_KEY, name, filepath],
     queryFn: () => getGeneratorFile(name, filepath),
+    enabled: options?.enabled ?? true,
   });
 }
 

--- a/eventum/ui/src/api/routes/generator-configs/index.ts
+++ b/eventum/ui/src/api/routes/generator-configs/index.ts
@@ -12,7 +12,7 @@ import {
   GeneratorFileContent,
   GeneratorFileContentSchema,
 } from './schemas';
-import { apiClient } from '@/api/client';
+import { apiClient, TRANSFER_TIMEOUT } from '@/api/client';
 import '@/api/routes/instance/schemas';
 import { validateResponse } from '@/api/wrappers';
 
@@ -90,6 +90,7 @@ export async function getGeneratorFile(
     GeneratorFileContentSchema,
     apiClient.get(`/generator-configs/${name}/file/${filepath}`, {
       responseType: 'text',
+      timeout: TRANSFER_TIMEOUT,
     })
   );
 }
@@ -115,6 +116,7 @@ export async function uploadGeneratorFile(
     headers: {
       'Content-Type': undefined,
     },
+    timeout: TRANSFER_TIMEOUT,
   });
 }
 
@@ -135,6 +137,7 @@ export async function putGeneratorFile(
     headers: {
       'Content-Type': undefined,
     },
+    timeout: TRANSFER_TIMEOUT,
   });
 }
 
@@ -160,8 +163,12 @@ export async function copyGeneratorFile(
   source: string,
   destination: string
 ) {
-  await apiClient.post(`/generator-configs/${name}/file-copy`, {
-    source,
-    destination,
-  });
+  await apiClient.post(
+    `/generator-configs/${name}/file-copy`,
+    {
+      source,
+      destination,
+    },
+    { timeout: TRANSFER_TIMEOUT }
+  );
 }

--- a/eventum/ui/src/api/routes/generator-configs/modules/file-tree/index.ts
+++ b/eventum/ui/src/api/routes/generator-configs/modules/file-tree/index.ts
@@ -55,6 +55,26 @@ export function flattenFileTree(
   return result;
 }
 
+export function findFileNode(
+  fileTree: FileNode[],
+  path: string
+): FileNode | undefined {
+  let nodes: FileNode[] | null = fileTree;
+  let node: FileNode | undefined;
+
+  for (const segment of path.split('/')) {
+    node = nodes?.find((candidate) => candidate.name === segment);
+
+    if (node === undefined) {
+      return undefined;
+    }
+
+    nodes = node.children;
+  }
+
+  return node;
+}
+
 export function createFileTreeLookup(fileTree: FileNode[]) {
   const items = new Map<string, FileNode>();
   const children = new Map<string, string[]>();

--- a/eventum/ui/src/api/routes/generator-configs/schemas/index.ts
+++ b/eventum/ui/src/api/routes/generator-configs/schemas/index.ts
@@ -45,12 +45,15 @@ const FileNodeSchema: z.ZodType = z.lazy(() =>
   z.object({
     name: z.string(),
     is_dir: z.boolean(),
+    size_in_bytes: z.number().int().nullable(),
     children: z.array(FileNodeSchema).nullable().optional(),
   })
 );
 export interface FileNode {
   name: string;
   is_dir: boolean;
+  // Set for files only, and null when the size cannot be read.
+  size_in_bytes: number | null;
   children: FileNode[] | null;
 }
 

--- a/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/index.tsx
+++ b/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/index.tsx
@@ -8,17 +8,25 @@ import { keymap } from '@codemirror/view';
 import { Alert, Box, Skeleton, useMantineColorScheme } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import CodeMirror from '@uiw/react-codemirror';
+import bytes from 'bytes';
 import { FC, useEffect, useRef, useState } from 'react';
 
 import { jinjaCompletion } from './completions';
 import {
   useGeneratorFileContent,
+  useGeneratorFileTree,
   usePutGeneratorFileMutation,
 } from '@/api/hooks/useGeneratorConfigs';
+import { findFileNode } from '@/api/routes/generator-configs/modules/file-tree';
 import { AlertIcon } from '@/components/ui/AlertIcon';
 import { ShowErrorDetailsAnchor } from '@/components/ui/ShowErrorDetailsAnchor';
 import { useProjectName } from '@/pages/ProjectPage/hooks/useProjectName';
 import { cmTheme } from '@/theme/codemirror';
+
+// Files above this size are not requested at all: transferring one takes
+// as long as the link needs, and the editor cannot usefully display it.
+// Generator output files are the usual case - they grow without a bound.
+const MAX_EDITABLE_SIZE = 10 * 1024 * 1024;
 
 export interface FileEditorProps {
   filePath: string;
@@ -35,13 +43,27 @@ export const FileEditor: FC<FileEditorProps> = ({
 }) => {
   const { colorScheme } = useMantineColorScheme();
   const { projectName } = useProjectName();
+
+  // The file tree carries the size of every file, so an oversized file is
+  // recognized before its content is requested. Until the tree resolves
+  // the size is unknown and the request waits.
+  const { data: fileTree, isPending: isFileTreePending } =
+    useGeneratorFileTree(projectName);
+  const fileSize =
+    fileTree === undefined
+      ? null
+      : (findFileNode(fileTree, filePath)?.size_in_bytes ?? null);
+  const isTooLarge = fileSize !== null && fileSize > MAX_EDITABLE_SIZE;
+
   const {
     data: fileContent,
     isLoading: isContentLoading,
     isError: isContentError,
     error: contentError,
     isSuccess: isContentSuccess,
-  } = useGeneratorFileContent(projectName, filePath);
+  } = useGeneratorFileContent(projectName, filePath, {
+    enabled: !isFileTreePending && !isTooLarge,
+  });
   const updateFile = usePutGeneratorFileMutation();
 
   const [content, setContent] = useState<string>('');
@@ -124,7 +146,22 @@ export const FileEditor: FC<FileEditorProps> = ({
 
   extensions.push(saveKeymap);
 
-  if (isContentLoading) {
+  if (isTooLarge) {
+    return (
+      <Box p="md">
+        <Alert
+          variant="default"
+          icon={<AlertIcon variant="warn" />}
+          title="File is too large to open"
+        >
+          {bytes(fileSize)} exceeds the editor limit of{' '}
+          {bytes(MAX_EDITABLE_SIZE)}. Open the file outside of Studio.
+        </Alert>
+      </Box>
+    );
+  }
+
+  if (isFileTreePending || isContentLoading) {
     return <Skeleton h={height} />;
   }
 

--- a/eventum/ui/src/pages/ProjectPage/common/FileTree/Tree/TreeItem.tsx
+++ b/eventum/ui/src/pages/ProjectPage/common/FileTree/Tree/TreeItem.tsx
@@ -9,6 +9,7 @@ import {
   IconFolderPlus,
   IconTrash,
 } from '@tabler/icons-react';
+import bytes from 'bytes';
 import { useContextMenu } from 'mantine-contextmenu';
 import { dirname, join } from 'pathe';
 import { FC } from 'react';
@@ -40,6 +41,8 @@ export const TreeItem: FC<TreeItemProps> = ({
 
   const { showContextMenu } = useContextMenu();
   const createDir = useCreateGeneratorDirectoryMutation();
+
+  const fileSize = item.isFolder() ? null : item.getItemData().size_in_bytes;
 
   return (
     <NavLink
@@ -199,6 +202,11 @@ export const TreeItem: FC<TreeItemProps> = ({
             />
           ) : (
             <Text size="sm">{item.getItemName()}</Text>
+          )}
+          {fileSize !== null && !item.isRenaming() && (
+            <Text size="xs" c="dimmed" ml="auto" style={{ flexShrink: 0 }}>
+              {bytes(fileSize)}
+            </Text>
           )}
         </Group>
       }

--- a/eventum/ui/src/pages/ProjectPage/common/FileTree/Tree/index.tsx
+++ b/eventum/ui/src/pages/ProjectPage/common/FileTree/Tree/index.tsx
@@ -163,6 +163,7 @@ export const Tree: FC<TreeProps> = ({ fileTreeLookup }) => {
         fileTreeLookup.items.get(itemId) ?? {
           name: '',
           is_dir: false,
+          size_in_bytes: null,
           children: [],
         },
       getChildren: (itemId) => fileTreeLookup.children.get(itemId) ?? [],


### PR DESCRIPTION
Closes #180.

The report carried two independent defects. A timeout bump alone fixes neither the traceback nor the class of requests behind it, so this covers both, plus the size exposure the same file paths had on the MCP side.

## Studio request deadlines

One 10-second deadline covered every request, including those whose duration is set by the size of the file they move rather than by the health of the backend. Reading, uploading or copying a large project file failed while the transfer was still progressing.

- Those four requests now run without a deadline; everything else has 60 seconds, enough for the directory walks and preview runs the backend performs on request.
- A request that ends on its deadline is reported as a timeout instead of a generic failure.

## The traceback: `LocalProtocolError: Too much data for declared Content-Length`

Starlette's `FileResponse` stats the file to declare `Content-Length` and only then opens and streams it. A file a generator is appending to outgrows the declared length and h11 kills the response mid-body; a truncated file breaks it the other way.

The route now opens the file itself and streams at most the bytes it held at that moment, with no declared length, so the body is a deterministic snapshot and concurrent writes cannot break the framing. Opening in the handler also makes the documented `500` real - the old `try/except` around the `FileResponse` constructor could never fire, because the stat and the read happened after the handler returned.

Verified against a file growing at ~20 MB/s: 8 of 8 reads complete with no protocol errors, where the same scenario on `develop` aborts the connection and logs the reported error four times.

## File sizes in Studio, and a limit on what the editor opens

`/file-tree` reports `size_in_bytes` per file (null for directories and for a file that cannot be stat'ed, so a broken symlink no longer fails the whole tree). The tree shows the size next to each name, and a file over 10 MB is not requested at all - the editor reports its size and the limit. The check uses the tree the panel already loads, so it costs no extra request.

## MCP file access

Same exposure on the agent side, since the allow-list covers `.json` and `.csv` - exactly what a long run writes.

- `read_generator_file` returns at most 64 KB (256 KB on request), ending on a complete line, with the file size and the offset to continue from, so an agent pages through anything larger. Bounded windows read by byte offset, the way the log tail is already bounded.
- `describe_sample` parses a sample whole, as a run would load it, so it refuses a file above 32 MB and points at the windowed read. Anything a generator would actually load describes exactly as before.
- The authoring prompt tells the agent how to page a read.

## Verification

`ruff check` / `ruff format --check` / `mypy` clean; `pytest` 1398 passed (+26 tests); `pnpm build` and `pnpm lint` clean in `ui/`.

Docs: eventum-generator/docs#49 (file tree note, MCP tools table, re-exported API schema). Filed along the way: #192 (the published OpenAPI schema drifts, with no export entry point or CI guard) and #193 (`pnpm generate-api-docs` empties the API reference index).
