### PR TITLE
fix(plugins): report a failed bind of the http input plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 
 - **Restored parallel generation alongside the `clickhouse` output** — loading the plugin on free-threaded Python re-enabled the GIL for the whole process, so every generator lost parallelism, not only the one writing to ClickHouse. The ClickHouse client is now required at a version whose compiled modules keep the GIL disabled
 - **Dropped the unsatisfiable constraint on the `clickhouse` certificate fields** — `ca_cert`, `client_cert` and `client_cert_key` carried a text-length constraint that cannot apply to a path, so any value failed with a type error while the configuration was read, leaving certificate-based TLS unusable
+- **Reported a failed bind of the `http` input as a generation error** — a generator whose port was already taken produced no timestamps and no diagnosis; it now fails with the bind address and the server exit code
 
 #### MCP
 

--- a/eventum/plugins/input/plugins/http/plugin.py
+++ b/eventum/plugins/input/plugins/http/plugin.py
@@ -17,6 +17,31 @@ from eventum.plugins.input.plugins.http.config import HttpInputPluginConfig
 from eventum.plugins.input.utils.time_utils import now64
 
 
+def _describe_server_error(error: BaseException) -> str:
+    """Describe server failure for error context.
+
+    Parameters
+    ----------
+    error : BaseException
+        Error to describe.
+
+    Returns
+    -------
+    str
+        Human readable description of the error.
+
+    Notes
+    -----
+    Uvicorn reports a failed bind by calling `sys.exit`, and the
+    resulting `SystemExit` carries only the exit code.
+
+    """
+    if isinstance(error, SystemExit):
+        return f'Server exited with code {error.code}'
+
+    return str(error)
+
+
 class GenerateRequestData(BaseModel, extra='forbid', frozen=True):
     """Data for generate request.
 
@@ -86,6 +111,7 @@ class HttpInputPlugin(
             maxsize=config.max_pending_requests,
         )
         self._is_stopping = False
+        self._server_error: BaseException | None = None
 
     async def _handle_generate(
         self,
@@ -148,18 +174,20 @@ class HttpInputPlugin(
         future : Future
             Done future.
 
+        Notes
+        -----
+        The failure is saved instead of being raised - this callback
+        runs in whichever thread completed the future, where a raised
+        exception is only logged. `_generate` raises it once the request
+        queue is unblocked.
+
         """
         try:
             future.result()
-        except Exception as e:
+        except (Exception, SystemExit) as e:  # noqa: BLE001
             self._is_stopping = True
             self._server.should_exit = True
-
-            msg = 'Error during server execution'
-            raise PluginGenerationError(
-                msg,
-                context={'reason': str(e)},
-            ) from e
+            self._server_error = e
         finally:
             self._request_queue.put(None)
 
@@ -193,7 +221,19 @@ class HttpInputPlugin(
                     continue
 
                 if count is None:
-                    break
+                    error = self._server_error
+                    if error is None:
+                        break
+
+                    msg = 'Error during server execution'
+                    raise PluginGenerationError(
+                        msg,
+                        context={
+                            'reason': _describe_server_error(error),
+                            'host': self._config.host,
+                            'port': self._config.port,
+                        },
+                    ) from error
 
                 self._buffer.m_push(
                     timestamp=now64(self._timezone),

--- a/eventum/plugins/input/plugins/http/tests/test_plugin.py
+++ b/eventum/plugins/input/plugins/http/tests/test_plugin.py
@@ -1,51 +1,119 @@
+"""Tests for http input plugin."""
+
 import socket
 import time
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Iterator
+from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import contextmanager
+from http import HTTPStatus
+from zoneinfo import ZoneInfo
 
 import pytest
 import requests as rq  # type: ignore[import-untyped]
-from zoneinfo import ZoneInfo
+from numpy import datetime64
 
+from eventum.plugins.input.exceptions import PluginGenerationError
 from eventum.plugins.input.plugins.http.config import HttpInputPluginConfig
 from eventum.plugins.input.plugins.http.plugin import HttpInputPlugin
 
+HOST = '127.0.0.1'
+STARTUP_TIMEOUT = 15.0
+REQUEST_TIMEOUT = 15.0
+REQUESTS = 5
+COUNT_PER_REQUEST = 2
+
+
+def _make_plugin(port: int) -> HttpInputPlugin:
+    return HttpInputPlugin(
+        config=HttpInputPluginConfig(host=HOST, port=port),
+        params={
+            'id': 1,
+            'timezone': ZoneInfo('UTC'),
+        },
+    )
+
+
+@contextmanager
+def _taken_port() -> Iterator[int]:
+    """Listen on an ephemeral port and yield it."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((HOST, 0))
+        sock.listen(1)
+        yield sock.getsockname()[1]
+
+
+def _free_port() -> int:
+    """Return a port that is free at the moment of the call."""
+    with _taken_port() as port:
+        return port
+
+
+def _wait_until_started(plugin: HttpInputPlugin, future: Future) -> None:
+    """Wait until the plugin's own server accepts interaction.
+
+    Raises
+    ------
+    TimeoutError
+        If the server does not start within the timeout.
+
+    """
+    deadline = time.monotonic() + STARTUP_TIMEOUT
+    while not plugin.can_interact:
+        if future.done():
+            # Re-raises the failure that stopped the server
+            future.result()
+
+            msg = 'Http server stopped before it started serving'
+            raise TimeoutError(msg)
+
+        if time.monotonic() > deadline:
+            msg = 'Http server did not start in time'
+            raise TimeoutError(msg)
+
+        time.sleep(0.01)
+
 
 @pytest.mark.filterwarnings('ignore:websockets')
-def test_plugin():
+def test_plugin() -> None:
+    """Each request generates the requested number of timestamps."""
+    port = _free_port()
+    plugin = _make_plugin(port)
+    url = f'http://{HOST}:{port}'
+
+    timestamps: list[datetime64] = []
+
+    def generate() -> None:
+        for batch in plugin.generate(size=100):
+            timestamps.extend(batch)
+
     with ThreadPoolExecutor(max_workers=1) as executor:
-        plugin = HttpInputPlugin(
-            config=HttpInputPluginConfig(port=8080),
-            params={
-                'id': 1,
-                'timezone': ZoneInfo('UTC'),
-            },
-        )
-
-        timestamps = []
-
-        def generate():
-            for batch in plugin.generate(size=100):
-                timestamps.extend(batch)
-
         future = executor.submit(generate)
 
-        # wait for http server to start
-        while True:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            result = sock.connect_ex(('127.0.0.1', 8080))
-            sock.close()
-            if result == 0:
-                break
-            time.sleep(0.1)
+        _wait_until_started(plugin, future)
 
-        for _ in range(5):
-            res = rq.post('http://localhost:8080/generate', json={'count': 2})
-            assert res.status_code == 201
+        for _ in range(REQUESTS):
+            res = rq.post(
+                f'{url}/generate',
+                json={'count': COUNT_PER_REQUEST},
+                timeout=REQUEST_TIMEOUT,
+            )
+            assert res.status_code == HTTPStatus.CREATED
 
-        res = rq.post('http://localhost:8080/stop')
+        res = rq.post(f'{url}/stop', timeout=REQUEST_TIMEOUT)
 
-        assert res.status_code == 200
+        assert res.status_code == HTTPStatus.OK
 
         future.result()
 
-        assert len(timestamps) == 10
+    assert len(timestamps) == REQUESTS * COUNT_PER_REQUEST
+
+
+@pytest.mark.filterwarnings('ignore:websockets')
+def test_plugin_with_taken_port() -> None:
+    """Occupied bind port surfaces as a generation error."""
+    with _taken_port() as port:
+        plugin = _make_plugin(port)
+
+        with pytest.raises(PluginGenerationError):
+            for _ in plugin.generate(size=100):
+                pass


### PR DESCRIPTION
Found while investigating why `input/plugins/http::test_plugin` failed intermittently during the work on #184.

## The flake

The test bound a **fixed port 8080** and its readiness probe was a raw `connect_ex` against it, which cannot tell the plugin's own server from any other listener. Two consequences, both reproduced deterministically:

- **Something else listens on 8080.** The probe succeeds instantly against the stranger, the requests go there, and since `requests` carried no timeout the test hangs — 117 s in a controlled run, bounded only by the other side going away. Meanwhile the plugin's own uvicorn had already died on the failed bind.
- **Two test runs at once** (parallel suites, concurrent CI jobs). Both fail: the run that won the bind gets the other run's requests and an early `/stop` (`assert 14 == 10`), and the run that lost the bind posts into a server already stopping (`assert 409 == 201`) plus `SystemExit: 1` from its own uvicorn.

The test now takes an ephemeral port, waits on `plugin.can_interact` — the plugin's own server, not "someone listens here" — with a deadline and an early `future.done()` check, and passes a timeout to every request.

## The plugin bug behind it

Uvicorn reports a failed bind by calling `sys.exit(1)`, and `SystemExit` is not an `Exception`, so `_watch_server` never translated a taken port into `PluginGenerationError`.

Fixing only the `except` clause would have worked by luck. The callback runs in whichever thread completed the future: on an immediate bind failure the future is already done when `add_done_callback` is called, so the callback runs inline in the generator thread and the exception reaches the caller. When the server dies later, the callback runs in the server thread, where `concurrent.futures` logs the exception and drops it — the generator then ended silently through `finally: put(None)`, yielding no timestamps and no diagnosis.

So the failure is now stored and raised by the generator loop once the queue is unblocked, which surfaces it identically in both cases:

```
PluginGenerationError: Error during server execution
context: {'reason': 'Server exited with code 1', 'host': '127.0.0.1', 'port': 45593}
cause:   SystemExit
```

`reason`, `host` and `port` are existing `LOGGING.md` fields. The handler catches `(Exception, SystemExit)` rather than `BaseException`, so `KeyboardInterrupt` still propagates as before.

## Tests

`test_plugin_with_taken_port` pins the new behaviour: an occupied bind port raises `PluginGenerationError`.

`ruff check`, `ruff format --check`, `mypy` and `pytest --ignore=tests/integration` (1377 passed) are green. As the adversarial check, three concurrent runs of this test file alongside a full suite run — which also runs it — all pass; before the change two concurrent runs were enough to fail both.