### PR TITLE
fix(plugins): drop unsatisfiable min_length on opensearch and http cert fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file.
 
 - **Restored parallel generation alongside the `clickhouse` output** — loading the plugin on free-threaded Python re-enabled the GIL for the whole process, so every generator lost parallelism, not only the one writing to ClickHouse. The ClickHouse client is now required at a version whose compiled modules keep the GIL disabled
 - **Dropped the unsatisfiable constraint on the `clickhouse` certificate fields** — `ca_cert`, `client_cert` and `client_cert_key` carried a text-length constraint that cannot apply to a path, so any value failed with a type error while the configuration was read, leaving certificate-based TLS unusable
+- **Dropped the same unsatisfiable constraint on the `opensearch` and `http` output certificate fields**. `ca_cert`, `client_cert` and `client_cert_key` carried a text-length constraint that cannot apply to a path, so setting any of them failed with a type error while the configuration was read, leaving certificate-based TLS unusable for both plugins
 - **Reported a failed bind of the `http` input as a generation error** — a generator whose port was already taken produced no timestamps and no diagnosis; it now fails with the bind address and the server exit code
 
 #### MCP

--- a/eventum/plugins/output/plugins/http/config.py
+++ b/eventum/plugins/output/plugins/http/config.py
@@ -84,9 +84,9 @@ class HttpOutputPluginConfig(OutputPluginConfig, frozen=True):
     connect_timeout: int = Field(default=10, ge=1)
     request_timeout: int = Field(default=300, ge=1)
     verify: bool = Field(default=False)
-    ca_cert: Path | None = Field(default=None, min_length=1)
-    client_cert: Path | None = Field(default=None, min_length=1)
-    client_cert_key: Path | None = Field(default=None, min_length=1)
+    ca_cert: Path | None = Field(default=None)
+    client_cert: Path | None = Field(default=None)
+    client_cert_key: Path | None = Field(default=None)
     proxy_url: HttpUrl | None = Field(default=None)
     formatter: FormatterConfigT = Field(
         default_factory=lambda: JsonFormatterConfig(

--- a/eventum/plugins/output/plugins/http/tests/test_config.py
+++ b/eventum/plugins/output/plugins/http/tests/test_config.py
@@ -1,0 +1,27 @@
+"""Tests for http output plugin config."""
+
+from pathlib import Path
+
+from eventum.plugins.output.plugins.http.config import (
+    HttpOutputPluginConfig,
+)
+
+
+def test_ca_cert_accepts_path() -> None:
+    """A `ca_cert` path is accepted and stored as a `Path`."""
+    config = HttpOutputPluginConfig(
+        url='https://localhost:8080',
+        ca_cert='certs/ca.pem',
+    )
+    assert config.ca_cert == Path('certs/ca.pem')
+
+
+def test_client_cert_pair_accepts_paths() -> None:
+    """`client_cert` and `client_cert_key` paths are accepted together."""
+    config = HttpOutputPluginConfig(
+        url='https://localhost:8080',
+        client_cert='certs/client.pem',
+        client_cert_key='certs/client.key',
+    )
+    assert config.client_cert == Path('certs/client.pem')
+    assert config.client_cert_key == Path('certs/client.key')

--- a/eventum/plugins/output/plugins/opensearch/config.py
+++ b/eventum/plugins/output/plugins/opensearch/config.py
@@ -68,9 +68,9 @@ class OpensearchOutputPluginConfig(OutputPluginConfig, frozen=True):
     connect_timeout: int = Field(default=10, ge=1)
     request_timeout: int = Field(default=300, ge=1)
     verify: bool = Field(default=False)
-    ca_cert: Path | None = Field(default=None, min_length=1)
-    client_cert: Path | None = Field(default=None, min_length=1)
-    client_cert_key: Path | None = Field(default=None, min_length=1)
+    ca_cert: Path | None = Field(default=None)
+    client_cert: Path | None = Field(default=None)
+    client_cert_key: Path | None = Field(default=None)
     proxy_url: HttpUrl | None = Field(default=None)
     formatter: FormatterConfigT = Field(
         default_factory=lambda: JsonFormatterConfig(

--- a/eventum/plugins/output/plugins/opensearch/tests/test_config.py
+++ b/eventum/plugins/output/plugins/opensearch/tests/test_config.py
@@ -1,0 +1,33 @@
+"""Tests for opensearch output plugin config."""
+
+from pathlib import Path
+
+from eventum.plugins.output.plugins.opensearch.config import (
+    OpensearchOutputPluginConfig,
+)
+
+
+def test_ca_cert_accepts_path() -> None:
+    """A `ca_cert` path is accepted and stored as a `Path`."""
+    config = OpensearchOutputPluginConfig(
+        hosts=['https://localhost:9200'],
+        index='i',
+        username='u',
+        password='p',  # noqa: S106
+        ca_cert='certs/ca.pem',
+    )
+    assert config.ca_cert == Path('certs/ca.pem')
+
+
+def test_client_cert_pair_accepts_paths() -> None:
+    """`client_cert` and `client_cert_key` paths are accepted together."""
+    config = OpensearchOutputPluginConfig(
+        hosts=['https://localhost:9200'],
+        index='i',
+        username='u',
+        password='p',  # noqa: S106
+        client_cert='certs/client.pem',
+        client_cert_key='certs/client.key',
+    )
+    assert config.client_cert == Path('certs/client.pem')
+    assert config.client_cert_key == Path('certs/client.key')


### PR DESCRIPTION
## Summary

The `ca_cert`, `client_cert` and `client_cert_key` fields on the `opensearch` and `http` output plugins are declared as `Path` but carry a `min_length=1` constraint. `min_length` is a sequence constraint that pydantic cannot apply to a `Path` (`len(PosixPath(...))` raises), so reading a config that sets any of them fails with a raw `TypeError: Unable to apply constraint 'min_length' to supplied value ...` instead of accepting the path. That makes certificate-based TLS unusable for both plugins.

This drops `min_length` from the six declarations, matching the other `Path` fields in the codebase and the `clickhouse` output, where the same defect was fixed in #189. Added regression tests for both plugins.

## Related issue

Closes #190.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or internal change
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Branched off `develop` and targeting `develop`.
- [x] Tests added or updated, co-located under `<package>/tests/`.
- [x] `uv run ruff format` and `uv run ruff check` pass.
- [x] `uv run mypy eventum/` passes.
- [x] `uv run pytest` passes.
- [ ] For UI changes: `pnpm lint` and `pnpm build` pass.
- [x] Commit messages follow Conventional Commits with a valid package scope.
- [ ] Documentation updated if behavior changed.
