### PR TITLE
fix(plugins): correct the certificate docstrings in the opensearch and http outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,7 @@ All notable changes to this project will be documented in this file.
 #### Plugins
 
 - **Restored parallel generation alongside the `clickhouse` output** — loading the plugin on free-threaded Python re-enabled the GIL for the whole process, so every generator lost parallelism, not only the one writing to ClickHouse. The ClickHouse client is now required at a version whose compiled modules keep the GIL disabled
-- **Dropped the unsatisfiable constraint on the `clickhouse` certificate fields** — `ca_cert`, `client_cert` and `client_cert_key` carried a text-length constraint that cannot apply to a path, so any value failed with a type error while the configuration was read, leaving certificate-based TLS unusable
-- **Dropped the same unsatisfiable constraint on the `opensearch` and `http` output certificate fields**. `ca_cert`, `client_cert` and `client_cert_key` carried a text-length constraint that cannot apply to a path, so setting any of them failed with a type error while the configuration was read, leaving certificate-based TLS unusable for both plugins
+- **Dropped the unsatisfiable constraint on the certificate fields of the `clickhouse`, `opensearch` and `http` outputs** — `ca_cert`, `client_cert` and `client_cert_key` carried a text-length constraint that cannot apply to a path, so any value failed with a type error while the configuration was read, leaving certificate-based TLS unusable (thanks to @SAY-5!)
 - **Reported a failed bind of the `http` input as a generation error** — a generator whose port was already taken produced no timestamps and no diagnosis; it now fails with the bind address and the server exit code
 
 #### MCP

--- a/eventum/plugins/output/plugins/http/config.py
+++ b/eventum/plugins/output/plugins/http/config.py
@@ -45,17 +45,17 @@ class HttpOutputPluginConfig(OutputPluginConfig, frozen=True):
     request_timeout : int, default=300
         Requests timeout in seconds.
 
-    verify: bool, default=True
+    verify: bool, default=False
         Whether to verify SSL certificate of the server when
         connecting to it.
 
-    ca_cert: str | None, default=None
+    ca_cert: Path | None, default=None
         Path to CA certificate.
 
-    client_cert: str | None, default=None
+    client_cert: Path | None, default=None
         Path to client certificate.
 
-    client_cert_key: str | None, default=None
+    client_cert_key: Path | None, default=None
         Path to client certificate key.
 
     proxy_url : HttpUrl | None, default=None

--- a/eventum/plugins/output/plugins/http/tests/test_plugin.py
+++ b/eventum/plugins/output/plugins/http/tests/test_plugin.py
@@ -1,4 +1,6 @@
 import re
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from pydantic import HttpUrl
@@ -7,6 +9,22 @@ from pytest_httpx import HTTPXMock
 from eventum.plugins.output.fields import Format, JsonFormatterConfig
 from eventum.plugins.output.plugins.http.config import HttpOutputPluginConfig
 from eventum.plugins.output.plugins.http.plugin import HttpOutputPlugin
+
+_BASE_PATH = Path('/generators/demo')
+_SSL_CONTEXT_FACTORY = (
+    'eventum.plugins.output.plugins.http.plugin.create_ssl_context'
+)
+
+
+@pytest.fixture
+def tls_config():
+    return HttpOutputPluginConfig(
+        url='https://localhost:8000/endpoint',  # type: ignore[arg-type]
+        verify=True,
+        ca_cert='certs/ca.pem',  # type: ignore[arg-type]
+        client_cert='certs/client.pem',  # type: ignore[arg-type]
+        client_cert_key='certs/client-key.pem',  # type: ignore[arg-type]
+    )
 
 
 @pytest.mark.asyncio
@@ -77,3 +95,17 @@ async def test_plugin_wrong_code(httpx_mock: HTTPXMock):
         '{"@timestamp": "2024-01-01T00:00:00.000Z", "value": 1}'
     )
     assert written == 0
+
+
+def test_plugin_certificate_paths_resolved(tls_config):
+    with patch(_SSL_CONTEXT_FACTORY) as create_context:
+        HttpOutputPlugin(
+            config=tls_config,
+            params={'id': 1, 'base_path': _BASE_PATH},
+        )
+
+    options = create_context.call_args.kwargs
+    assert options['verify'] is True
+    assert options['ca_cert'] == _BASE_PATH / 'certs/ca.pem'
+    assert options['client_cert'] == _BASE_PATH / 'certs/client.pem'
+    assert options['client_key'] == _BASE_PATH / 'certs/client-key.pem'

--- a/eventum/plugins/output/plugins/opensearch/config.py
+++ b/eventum/plugins/output/plugins/opensearch/config.py
@@ -39,17 +39,17 @@ class OpensearchOutputPluginConfig(OutputPluginConfig, frozen=True):
     request_timeout : int, default=300
         Requests timeout in seconds.
 
-    verify: bool, default=True
+    verify: bool, default=False
         Whether to verify SSL certificate of the cluster nodes when
         connecting to them.
 
-    ca_cert: str | None, default=None
+    ca_cert: Path | None, default=None
         Path to CA certificate.
 
-    client_cert: str | None, default=None
+    client_cert: Path | None, default=None
         Path to client certificate.
 
-    client_cert_key: str | None, default=None
+    client_cert_key: Path | None, default=None
         Path to client certificate key.
 
     proxy_url : HttpUrl | None, default=None

--- a/eventum/plugins/output/plugins/opensearch/tests/test_plugin.py
+++ b/eventum/plugins/output/plugins/opensearch/tests/test_plugin.py
@@ -1,4 +1,6 @@
 import re
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from pytest_httpx import HTTPXMock
@@ -12,6 +14,11 @@ from eventum.plugins.output.plugins.opensearch.plugin import (
 
 pytest_plugins = ('pytest_asyncio',)
 
+_BASE_PATH = Path('/generators/demo')
+_SSL_CONTEXT_FACTORY = (
+    'eventum.plugins.output.plugins.opensearch.plugin.create_ssl_context'
+)
+
 
 @pytest.fixture
 def config():
@@ -21,6 +28,20 @@ def config():
         password='pass',
         index='test_index',
         verify=False,
+    )
+
+
+@pytest.fixture
+def tls_config():
+    return OpensearchOutputPluginConfig(
+        hosts=['https://localhost:9200'],  # type: ignore[arg-type]
+        username='admin',
+        password='pass',
+        index='test_index',
+        verify=True,
+        ca_cert='certs/ca.pem',  # type: ignore[arg-type]
+        client_cert='certs/client.pem',  # type: ignore[arg-type]
+        client_cert_key='certs/client-key.pem',  # type: ignore[arg-type]
     )
 
 
@@ -184,3 +205,17 @@ async def test_opensearch_write_many_partially_corrupted(
         '{"@timestamp": "2024-01-01T00:00:00.000Z", "value": 1}'
     )
     assert written == 1
+
+
+def test_opensearch_certificate_paths_resolved(tls_config):
+    with patch(_SSL_CONTEXT_FACTORY) as create_context:
+        OpensearchOutputPlugin(
+            config=tls_config,
+            params={'id': 1, 'base_path': _BASE_PATH},
+        )
+
+    options = create_context.call_args.kwargs
+    assert options['verify'] is True
+    assert options['ca_cert'] == _BASE_PATH / 'certs/ca.pem'
+    assert options['client_cert'] == _BASE_PATH / 'certs/client.pem'
+    assert options['client_key'] == _BASE_PATH / 'certs/client-key.pem'


### PR DESCRIPTION
## Summary

The `opensearch` and `http` output configs document their TLS options wrongly:

- `verify` is documented as defaulting to `True` while the field defaults to `False`
- `ca_cert`, `client_cert` and `client_cert_key` are documented as `str` although they are `Path`

Both are corrected, and each plugin gains a test that a configured certificate path reaches the SSL context resolved against the generator directory - the config-level acceptance was covered separately, this pins the plugin-level behaviour.

The changelog's two certificate-constraint entries are folded into one covering all three outputs, with credit to @SAY-5.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or internal change
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Branched off `develop` and targeting `develop`.
- [x] Tests added or updated, co-located under `<package>/tests/`.
- [x] `uv run ruff format` and `uv run ruff check` pass.
- [x] `uv run mypy eventum/` passes.
- [x] `uv run pytest` passes (1410 passed).
- [x] Commit messages follow Conventional Commits with a valid package scope.