### PR TITLE
feat(ui): rebuild the editor search panel on Studio controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - **Added a Clone action to the instance row menu** — creates a new instance from an existing one, reusing its project and all parameters
 - **Made Studio navigation link-based** — record names, sidebar items, breadcrumbs, home cards and in-page links are real links, so middle-click and Ctrl/Cmd-click open them in a new browser tab; middle-click also closes an editor tab. Selecting a record name no longer opens it, so names stay copyable
 - **Added file sizes to the project file tree** — every file shows its size next to its name, and a file over 10 MB is not opened in the editor: the tab reports the size and the limit instead of transferring a file the editor cannot display. Generator output files are the usual case
+- **Rebuilt the editor search panel** — Ctrl/Cmd-F opens a compact panel floating over the top-right corner of the editor instead of a strip stretched across its bottom edge. The query field counts the matches and marks a malformed expression, case, regular-expression and whole-word matching are icon toggles, and the replace row is revealed on demand
 
 #### MCP
 

--- a/eventum/ui/package.json
+++ b/eventum/ui/package.json
@@ -20,6 +20,7 @@
     "@codemirror/lang-yaml": "^6.1.2",
     "@codemirror/language": "^6.12.3",
     "@codemirror/lint": "^6.9.5",
+    "@codemirror/search": "^6.6.0",
     "@codemirror/state": "^6.5.3",
     "@codemirror/view": "^6.39.4",
     "@fontsource-variable/inter": "^5.2.8",

--- a/eventum/ui/pnpm-lock.yaml
+++ b/eventum/ui/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@codemirror/lint':
         specifier: ^6.9.5
         version: 6.9.5
+      '@codemirror/search':
+        specifier: ^6.6.0
+        version: 6.6.0
       '@codemirror/state':
         specifier: ^6.5.3
         version: 6.6.0

--- a/eventum/ui/src/index.css
+++ b/eventum/ui/src/index.css
@@ -21,6 +21,8 @@ svg.tabler-icon {
   font-size: 14px;
 }
 
+/* Panels CodeMirror builds itself - "go to line" is the one reachable in
+   Studio. The search panel is ours and needs none of this. */
 .cm-panel {
   .cm-textfield {
     border: 1px solid var(--mantine-color-default-border);
@@ -39,4 +41,25 @@ svg.tabler-icon {
   input[type='checkbox'] {
     cursor: pointer;
   }
+}
+
+/* CodeMirror docks panels across an editor edge, which would push the content
+   down and leave the search panel pressed against the console below. Taking
+   the container out of the flow floats the panel over the top-right corner
+   instead; the panel carries its own surface, so the container is left as a
+   bare positioner. */
+.cm-editor .cm-panels-top:has(.ev-cm-search) {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  left: auto;
+  max-width: calc(100% - 12px);
+  background-color: transparent;
+  border-bottom: none;
+}
+
+/* The editor theme paints its own foreground on the whole editor, which the
+   panel would inherit for anything not coloured by a Mantine component. */
+.ev-cm-search {
+  color: var(--mantine-color-text);
 }

--- a/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/SearchPanel/extension.ts
+++ b/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/SearchPanel/extension.ts
@@ -1,0 +1,89 @@
+import { search, setSearchQuery } from '@codemirror/search';
+import { Extension } from '@codemirror/state';
+import { EditorView, Panel, ViewUpdate } from '@codemirror/view';
+
+/**
+ * A search panel currently open in an editor. The extension owns the host
+ * element and the editor view; the controls are rendered into the host by
+ * React so they can read the app theme.
+ */
+export interface SearchPanelHandle {
+  readonly view: EditorView;
+  readonly dom: HTMLElement;
+  /** Register a listener for the updates the controls have to redraw for. */
+  subscribe: (listener: () => void) => () => void;
+}
+
+export interface SearchPanelHooks {
+  onOpen: (handle: SearchPanelHandle) => void;
+  onClose: (handle: SearchPanelHandle) => void;
+}
+
+// Keeps the match the search jumps to clear of the panel floating over the
+// top-right corner of the editor.
+const SCROLL_MARGIN = 48;
+
+class SearchPanelHost implements Panel {
+  readonly dom: HTMLElement;
+  readonly top = true;
+  readonly view: EditorView;
+
+  private readonly hooks: SearchPanelHooks;
+  private readonly listeners = new Set<() => void>();
+
+  constructor(view: EditorView, hooks: SearchPanelHooks) {
+    this.view = view;
+    this.hooks = hooks;
+    this.dom = document.createElement('div');
+    this.dom.className = 'ev-cm-search';
+  }
+
+  subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  // Both run inside the editor update the panel was added to or removed in,
+  // so the controls mount with the panel and unmount with it.
+  mount() {
+    this.hooks.onOpen(this);
+  }
+
+  destroy() {
+    this.hooks.onClose(this);
+  }
+
+  update(update: ViewUpdate) {
+    const requeried = update.transactions.some((transaction) =>
+      transaction.effects.some((effect) => effect.is(setSearchQuery))
+    );
+
+    // The query drives the fields, the document and the selection drive the
+    // match counter; nothing else on screen depends on the editor.
+    if (update.docChanged || update.selectionSet || requeried) {
+      for (const listener of this.listeners) {
+        listener();
+      }
+    }
+  }
+}
+
+/**
+ * Search extension that replaces the stock panel with the Studio one.
+ *
+ * The search keymap alone (bundled with the editor's basic setup) would open
+ * the library's own panel, so the whole extension is configured here instead.
+ */
+export function searchPanel(hooks: SearchPanelHooks): Extension {
+  return search({
+    createPanel: (view) => new SearchPanelHost(view, hooks),
+    scrollToMatch: (range) =>
+      EditorView.scrollIntoView(range, {
+        y: 'nearest',
+        yMargin: SCROLL_MARGIN,
+      }),
+  });
+}

--- a/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/SearchPanel/index.tsx
+++ b/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/SearchPanel/index.tsx
@@ -1,0 +1,318 @@
+import {
+  SearchQuery,
+  closeSearchPanel,
+  findNext,
+  findPrevious,
+  getSearchQuery,
+  replaceAll,
+  replaceNext,
+  selectMatches,
+  setSearchQuery,
+} from '@codemirror/search';
+import { EditorView, runScopeHandlers } from '@codemirror/view';
+import {
+  ActionIcon,
+  Group,
+  Paper,
+  Stack,
+  Text,
+  TextInput,
+  Tooltip,
+} from '@mantine/core';
+import {
+  IconAB,
+  IconChevronDown,
+  IconChevronRight,
+  IconChevronUp,
+  IconLetterCase,
+  IconRegex,
+  IconReplace,
+  IconReplaceFilled,
+  IconSelectAll,
+  IconX,
+} from '@tabler/icons-react';
+import {
+  FC,
+  KeyboardEvent,
+  ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+import { SearchPanelHandle } from './extension';
+import { MatchInfo, countMatches, formatMatchCount } from './matches';
+
+const FIELD_WIDTH = 190;
+const COUNTER_WIDTH = 54;
+const ICON_SIZE = 15;
+
+type SearchFlag = 'caseSensitive' | 'regexp' | 'wholeWord';
+
+type QueryChanges = Partial<{
+  search: string;
+  replace: string;
+  caseSensitive: boolean;
+  regexp: boolean;
+  wholeWord: boolean;
+}>;
+
+const FLAGS: { flag: SearchFlag; label: string; icon: typeof IconAB }[] = [
+  { flag: 'caseSensitive', label: 'Match case', icon: IconLetterCase },
+  { flag: 'regexp', label: 'Regular expression', icon: IconRegex },
+  { flag: 'wholeWord', label: 'Whole word', icon: IconAB },
+];
+
+interface Snapshot {
+  query: SearchQuery;
+  matches: MatchInfo | null;
+}
+
+function readSnapshot(view: EditorView): Snapshot {
+  const query = getSearchQuery(view.state);
+
+  return { query, matches: countMatches(view.state, query) };
+}
+
+function withChanges(query: SearchQuery, changes: QueryChanges): SearchQuery {
+  return new SearchQuery({
+    search: query.search,
+    caseSensitive: query.caseSensitive,
+    literal: query.literal,
+    regexp: query.regexp,
+    replace: query.replace,
+    wholeWord: query.wholeWord,
+    ...changes,
+  });
+}
+
+function flagChange(query: SearchQuery, flag: SearchFlag): QueryChanges {
+  const changes: QueryChanges = {};
+  changes[flag] = !query[flag];
+
+  return changes;
+}
+
+function runOnEnter(event: KeyboardEvent<HTMLInputElement>, run: () => void) {
+  if (event.key === 'Enter') {
+    event.preventDefault();
+    run();
+  }
+}
+
+interface PanelIconProps {
+  label: string;
+  /** Set on toggles only - it also marks the control as pressed. */
+  active?: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}
+
+const PanelIcon: FC<PanelIconProps> = ({
+  label,
+  active,
+  disabled,
+  onClick,
+  children,
+}) => (
+  <Tooltip label={label} withArrow>
+    <ActionIcon
+      variant={active ? 'light' : 'subtle'}
+      size="sm"
+      color={active ? 'primary' : 'var(--mantine-color-dimmed)'}
+      aria-label={label}
+      aria-pressed={active}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {children}
+    </ActionIcon>
+  </Tooltip>
+);
+
+export interface SearchPanelProps {
+  handle: SearchPanelHandle;
+}
+
+export const SearchPanel: FC<SearchPanelProps> = ({ handle }) => {
+  const { view, subscribe } = handle;
+
+  const [{ query, matches }, setSnapshot] = useState(() => readSnapshot(view));
+  const [replacing, setReplacing] = useState(false);
+
+  const queryField = useRef<HTMLInputElement>(null);
+
+  // The editor owns the query: every edit here is dispatched to it and comes
+  // back through this subscription, which also carries the changes made
+  // outside the panel (selecting the next occurrence, reopening the panel).
+  useEffect(
+    () => subscribe(() => setSnapshot(readSnapshot(view))),
+    [subscribe, view]
+  );
+
+  // Opening the panel selects the previous query so typing replaces it, and
+  // marks the field CodeMirror focuses when Ctrl/Cmd-F is pressed with the
+  // panel already open. The stock panel does both from its mount hook, which
+  // runs before React has rendered the field into the panel.
+  useEffect(() => {
+    const field = queryField.current;
+
+    if (field) {
+      field.setAttribute('main-field', 'true');
+      field.focus();
+      field.select();
+    }
+  }, []);
+
+  function commit(changes: QueryChanges) {
+    view.dispatch({ effects: setSearchQuery.of(withChanges(query, changes)) });
+  }
+
+  // Keeps Escape, F3 and Ctrl/Cmd-F working while the focus is in the panel.
+  function handleKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (runScopeHandlers(view, event.nativeEvent, 'search-panel')) {
+      event.preventDefault();
+    }
+  }
+
+  const malformed = query.regexp && query.search !== '' && !query.valid;
+
+  return (
+    <Paper withBorder p={6} onKeyDown={handleKeyDown}>
+      <Group gap={6} align="flex-start" wrap="nowrap">
+        <ActionIcon
+          variant="subtle"
+          size="sm"
+          color="var(--mantine-color-dimmed)"
+          aria-label={replacing ? 'Hide replace' : 'Show replace'}
+          aria-expanded={replacing}
+          onClick={() => setReplacing((shown) => !shown)}
+        >
+          {replacing ? (
+            <IconChevronDown size={ICON_SIZE} />
+          ) : (
+            <IconChevronRight size={ICON_SIZE} />
+          )}
+        </ActionIcon>
+
+        {/* Squeezed rather than clipped when the editor is narrow: the rows
+            wrap, the fields give up width and the close control stays in
+            reach. */}
+        <Stack gap={6} miw={0}>
+          <Group gap="xs">
+            <TextInput
+              ref={queryField}
+              size="xs"
+              w={FIELD_WIDTH}
+              miw={0}
+              placeholder="Find"
+              aria-label="Find"
+              error={malformed}
+              value={query.search}
+              onChange={(event) =>
+                commit({ search: event.currentTarget.value })
+              }
+              onKeyDown={(event) =>
+                runOnEnter(event, () =>
+                  (event.shiftKey ? findPrevious : findNext)(view)
+                )
+              }
+              // Kept mounted so the field does not reflow as the count
+              // appears and disappears.
+              rightSection={
+                <Text size="xs" c="dimmed">
+                  {matches && formatMatchCount(matches)}
+                </Text>
+              }
+              rightSectionWidth={COUNTER_WIDTH}
+              rightSectionPointerEvents="none"
+            />
+
+            <Group gap={2} wrap="nowrap">
+              {FLAGS.map(({ flag, label, icon: Icon }) => (
+                <PanelIcon
+                  key={flag}
+                  label={label}
+                  active={query[flag]}
+                  onClick={() => commit(flagChange(query, flag))}
+                >
+                  <Icon size={ICON_SIZE} />
+                </PanelIcon>
+              ))}
+            </Group>
+
+            <Group gap={2} wrap="nowrap">
+              <PanelIcon
+                label="Previous match"
+                disabled={!query.valid}
+                onClick={() => findPrevious(view)}
+              >
+                <IconChevronUp size={ICON_SIZE} />
+              </PanelIcon>
+              <PanelIcon
+                label="Next match"
+                disabled={!query.valid}
+                onClick={() => findNext(view)}
+              >
+                <IconChevronDown size={ICON_SIZE} />
+              </PanelIcon>
+              <PanelIcon
+                label="Select all matches"
+                disabled={!query.valid}
+                // The selection is only useful to type over, so hand the
+                // focus back to the editor along with it.
+                onClick={() => {
+                  selectMatches(view);
+                  view.focus();
+                }}
+              >
+                <IconSelectAll size={ICON_SIZE} />
+              </PanelIcon>
+            </Group>
+          </Group>
+
+          {replacing && (
+            <Group gap="xs">
+              <TextInput
+                size="xs"
+                w={FIELD_WIDTH}
+                miw={0}
+                placeholder="Replace"
+                aria-label="Replace"
+                value={query.replace}
+                onChange={(event) =>
+                  commit({ replace: event.currentTarget.value })
+                }
+                onKeyDown={(event) =>
+                  runOnEnter(event, () => replaceNext(view))
+                }
+              />
+
+              <Group gap={2} wrap="nowrap">
+                <PanelIcon
+                  label="Replace match"
+                  disabled={!query.valid}
+                  onClick={() => replaceNext(view)}
+                >
+                  <IconReplace size={ICON_SIZE} />
+                </PanelIcon>
+                <PanelIcon
+                  label="Replace all matches"
+                  disabled={!query.valid}
+                  onClick={() => replaceAll(view)}
+                >
+                  <IconReplaceFilled size={ICON_SIZE} />
+                </PanelIcon>
+              </Group>
+            </Group>
+          )}
+        </Stack>
+
+        <PanelIcon label="Close search" onClick={() => closeSearchPanel(view)}>
+          <IconX size={ICON_SIZE} />
+        </PanelIcon>
+      </Group>
+    </Paper>
+  );
+};

--- a/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/SearchPanel/matches.test.ts
+++ b/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/SearchPanel/matches.test.ts
@@ -1,0 +1,141 @@
+import { SearchQuery } from '@codemirror/search';
+import { EditorState } from '@codemirror/state';
+import { describe, expect, it } from 'vitest';
+
+import {
+  DOC_LIMIT,
+  MATCH_LIMIT,
+  countMatches,
+  formatMatchCount,
+} from './matches';
+
+function stateOf(doc: string, selection?: [number, number]): EditorState {
+  return EditorState.create({
+    doc,
+    selection: selection && { anchor: selection[0], head: selection[1] },
+  });
+}
+
+describe('countMatches', () => {
+  it('counts every occurrence in the document', () => {
+    expect(
+      countMatches(stateOf('a b a b a'), new SearchQuery({ search: 'a' }))
+    ).toEqual({ count: 3, current: null, capped: false });
+  });
+
+  it('locates the match the selection covers', () => {
+    expect(
+      countMatches(
+        stateOf('a b a b a', [4, 5]),
+        new SearchQuery({ search: 'a' })
+      )
+    ).toEqual({ count: 3, current: 2, capped: false });
+  });
+
+  it('reports no current match when the selection only touches one', () => {
+    // Caret parked at the start of the second match, nothing selected.
+    expect(
+      countMatches(
+        stateOf('a b a b a', [4, 4]),
+        new SearchQuery({ search: 'a' })
+      )?.current
+    ).toBeNull();
+  });
+
+  it('honours case sensitivity', () => {
+    const state = stateOf('Ab ab AB');
+
+    expect(countMatches(state, new SearchQuery({ search: 'ab' }))?.count).toBe(
+      3
+    );
+    expect(
+      countMatches(
+        state,
+        new SearchQuery({ search: 'ab', caseSensitive: true })
+      )?.count
+    ).toBe(1);
+  });
+
+  it('honours whole-word matching', () => {
+    const state = stateOf('log logger log');
+
+    expect(countMatches(state, new SearchQuery({ search: 'log' }))?.count).toBe(
+      3
+    );
+    expect(
+      countMatches(state, new SearchQuery({ search: 'log', wholeWord: true }))
+        ?.count
+    ).toBe(2);
+  });
+
+  it('counts regular expression matches', () => {
+    expect(
+      countMatches(
+        stateOf('id=1 id=22 name=x'),
+        new SearchQuery({ search: String.raw`id=\d+`, regexp: true })
+      )?.count
+    ).toBe(2);
+  });
+
+  it('skips an empty query', () => {
+    expect(
+      countMatches(stateOf('a b a'), new SearchQuery({ search: '' }))
+    ).toBeNull();
+  });
+
+  it('skips a malformed regular expression', () => {
+    expect(
+      countMatches(
+        stateOf('a b a'),
+        new SearchQuery({ search: 'a(', regexp: true })
+      )
+    ).toBeNull();
+  });
+
+  it('gives up once the scan hits the match limit', () => {
+    expect(
+      countMatches(
+        stateOf('a'.repeat(MATCH_LIMIT + 1)),
+        new SearchQuery({ search: 'a' })
+      )
+    ).toEqual({ count: MATCH_LIMIT, current: null, capped: true });
+  });
+
+  it('skips a document past the size limit', () => {
+    expect(
+      countMatches(
+        stateOf('x'.repeat(DOC_LIMIT + 1)),
+        new SearchQuery({ search: 'q' })
+      )
+    ).toBeNull();
+  });
+
+  it('terminates on a pattern that matches the empty string', () => {
+    expect(
+      countMatches(
+        stateOf('ab'),
+        new SearchQuery({ search: 'x*', regexp: true })
+      )?.capped
+    ).toBe(false);
+  });
+});
+
+describe('formatMatchCount', () => {
+  it('reads as the current match over the total', () => {
+    expect(formatMatchCount({ count: 17, current: 3, capped: false })).toBe(
+      '3/17'
+    );
+  });
+
+  it('falls back to zero when the cursor sits on no match', () => {
+    expect(formatMatchCount({ count: 17, current: null, capped: false })).toBe(
+      '0/17'
+    );
+  });
+
+  it('marks a capped total as open-ended', () => {
+    expect(
+      formatMatchCount({ count: MATCH_LIMIT, current: 3, capped: true })
+    ).toBe(`3/${MATCH_LIMIT}+`);
+  });
+});

--- a/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/SearchPanel/matches.ts
+++ b/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/SearchPanel/matches.ts
@@ -1,0 +1,69 @@
+import { SearchQuery } from '@codemirror/search';
+import { EditorState } from '@codemirror/state';
+
+/** Documents longer than this are not scanned for matches at all. */
+export const DOC_LIMIT = 200_000;
+
+/** A scan stops once it has found this many matches. */
+export const MATCH_LIMIT = 1000;
+
+export interface MatchInfo {
+  /** Matches found in the document, never above `MATCH_LIMIT`. */
+  count: number;
+  /** Position of the match the cursor sits on, counting from 1. */
+  current: number | null;
+  /** Whether the scan hit `MATCH_LIMIT` before reaching the end. */
+  capped: boolean;
+}
+
+/**
+ * Count the matches of `query` in the document and locate the one the
+ * selection covers.
+ *
+ * The scan runs on every edit and on every keystroke in the query field, so
+ * it is bounded at both ends: an oversized document (an opened sample or a
+ * captured log) is skipped entirely, and a scan gives up after `MATCH_LIMIT`
+ * matches. Returns `null` when there is nothing to count - an empty or
+ * malformed query, or a document past the size limit.
+ */
+export function countMatches(
+  state: EditorState,
+  query: SearchQuery
+): MatchInfo | null {
+  if (!query.valid || state.doc.length > DOC_LIMIT) {
+    return null;
+  }
+
+  const cursor = query.getCursor(state);
+  const selection = state.selection.main;
+
+  let count = 0;
+  let current: number | null = null;
+
+  for (let match = cursor.next(); !match.done; match = cursor.next()) {
+    count++;
+
+    if (
+      match.value.from === selection.from &&
+      match.value.to === selection.to
+    ) {
+      current = count;
+    }
+
+    if (count === MATCH_LIMIT) {
+      return { count, current, capped: true };
+    }
+  }
+
+  return { count, current, capped: false };
+}
+
+/**
+ * Render match counts for the query field: the match under the cursor over
+ * the total, `0` standing for a cursor that sits on no match.
+ */
+export function formatMatchCount(info: MatchInfo): string {
+  const total = info.capped ? `${MATCH_LIMIT}+` : `${info.count}`;
+
+  return `${info.current ?? 0}/${total}`;
+}

--- a/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/index.tsx
+++ b/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/index.tsx
@@ -9,8 +9,11 @@ import { Alert, Box, Skeleton, useMantineColorScheme } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import CodeMirror from '@uiw/react-codemirror';
 import bytes from 'bytes';
-import { FC, useEffect, useRef, useState } from 'react';
+import { FC, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
+import { SearchPanel } from './SearchPanel';
+import { SearchPanelHandle, searchPanel } from './SearchPanel/extension';
 import { jinjaCompletion } from './completions';
 import {
   useGeneratorFileContent,
@@ -68,6 +71,21 @@ export const FileEditor: FC<FileEditorProps> = ({
 
   const [content, setContent] = useState<string>('');
   const [isTouched, setTouched] = useState(false);
+
+  // The search panel is a CodeMirror panel with a React body: the extension
+  // hands over the element it mounted, the controls are rendered into it.
+  const [searchHandle, setSearchHandle] = useState<SearchPanelHandle | null>(
+    null
+  );
+  const searchExtension = useMemo(
+    () =>
+      searchPanel({
+        onOpen: setSearchHandle,
+        onClose: (closed) =>
+          setSearchHandle((current) => (current === closed ? null : current)),
+      }),
+    []
+  );
 
   useEffect(() => {
     if (isContentSuccess) {
@@ -144,7 +162,7 @@ export const FileEditor: FC<FileEditorProps> = ({
     extensions.push(markdown());
   }
 
-  extensions.push(saveKeymap);
+  extensions.push(saveKeymap, searchExtension);
 
   if (isTooLarge) {
     return (
@@ -182,19 +200,23 @@ export const FileEditor: FC<FileEditorProps> = ({
 
   if (isContentSuccess) {
     return (
-      <CodeMirror
-        value={content}
-        onChange={(value) => {
-          setContent(value);
+      <>
+        <CodeMirror
+          value={content}
+          onChange={(value) => {
+            setContent(value);
 
-          if (!isTouched) {
-            setTouched(true);
-          }
-        }}
-        height={height}
-        extensions={extensions}
-        theme={cmTheme(colorScheme)}
-      />
+            if (!isTouched) {
+              setTouched(true);
+            }
+          }}
+          height={height}
+          extensions={extensions}
+          theme={cmTheme(colorScheme)}
+        />
+        {searchHandle &&
+          createPortal(<SearchPanel handle={searchHandle} />, searchHandle.dom)}
+      </>
     );
   }
 


### PR DESCRIPTION
Closes #196

The editor mounted CodeMirror's stock search panel — bare textfields and buttons, native checkboxes with lowercase library labels, stretched over two rows across the bottom edge against the console divider. After the restyle (#179) it was the last surface on the project page reading as a browser default.

## What changed

- **Own panel, library behaviour.** Configured through `search({ createPanel })`, so the `Ctrl/Cmd-F` keymap bundled with the editor's basic setup opens ours instead of the library's. Every command stays the library's — `setSearchQuery`, `findNext`, `findPrevious`, `selectMatches`, `replaceNext`, `replaceAll`, `closeSearchPanel` — plus `runScopeHandlers` so Escape, F3 and `Ctrl/Cmd-F` keep working while the focus is in the panel.
- **Mantine controls in a CodeMirror panel.** The extension owns the host element; the controls are rendered into it with a React portal, which is what lets them read the app theme (a separate React root would lose the provider).
- **The editor owns the query.** Each edit dispatches `setSearchQuery` and comes back through the panel's subscription, so changes made outside the panel — selecting the next occurrence, reopening it — land in the fields too.
- **Compact layout.** One row for the query with previous / next / select-all / close as icon buttons; case, regular-expression and whole-word matching as `Aa` / `.*` / `ab` toggles; the replace row revealed on demand. Floats over the top-right corner instead of docking across an edge, so it neither pushes the content down nor meets the console.
- **Match counter.** The query field counts the matches and marks a malformed expression. Counting walks the document on every keystroke, so it is bounded at both ends: a document past 200k characters is skipped and a scan gives up after 1000 matches.
- **Narrow editors.** The fields give up width and the rows wrap, keeping the close control in reach.

Both colour schemes read from the theme. The panel resets the text colour the editor theme paints on itself; the `.cm-panel` rules stay in place for the "go to line" dialog, which is still the library's.

## Verification

- `pnpm build`, `pnpm lint`, `pnpm lint:css`, Prettier — clean.
- `pnpm test` — 41 passed, 13 of them new over the match counting (counts, current match, case / whole-word / regexp modes, malformed pattern, both limits, a pattern matching the empty string).
- Driven in a running Studio across 20 scenarios: counter stepping with Enter / Shift+Enter, case toggle changing the count, a malformed expression marking the field and disabling navigation, replace all rewriting the document, Escape closing and returning the focus to the editor, `Ctrl/Cmd-F` refocusing the query field with the panel already open. Both colour schemes and a 210px-wide editor checked visually; the "go to line" dialog confirmed unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)