### PR TITLE
fix(plugins): verify TLS certificates by default in the opensearch and http outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to this project will be documented in this file.
 
 - **Restored parallel generation alongside the `clickhouse` output** — loading the plugin on free-threaded Python re-enabled the GIL for the whole process, so every generator lost parallelism, not only the one writing to ClickHouse. The ClickHouse client is now required at a version whose compiled modules keep the GIL disabled
 - **Dropped the unsatisfiable constraint on the certificate fields of the `clickhouse`, `opensearch` and `http` outputs** — `ca_cert`, `client_cert` and `client_cert_key` carried a text-length constraint that cannot apply to a path, so any value failed with a type error while the configuration was read, leaving certificate-based TLS unusable (thanks to @SAY-5!)
+- **Turned certificate verification on by default in the `opensearch` and `http` outputs** — `verify` defaulted to `false`, so an `https://` endpoint was trusted without any check unless verification was requested explicitly, while `clickhouse` and `tcp` checked the same connection. A generator writing to an endpoint with a self-signed or internal-CA certificate now fails with a certificate error: point `ca_cert` at the issuing CA, or set `verify: false` to keep the connection unchecked
 - **Reported a failed bind of the `http` input as a generation error** — a generator whose port was already taken produced no timestamps and no diagnosis; it now fails with the bind address and the server exit code
 
 #### MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 - **Restricted the Write timeout field to whole seconds** — it accepted fractional values that the configuration then rejected on save
 - **Read the cron seconds field in the generator's order** — the text under the cron Expression field took the seconds as the first field, so `35 10 * * * 3` was described as "At 35 seconds past the minute … only on Wednesday" while the generator fires at 10:35:03 every day. The description and the validity check now follow `minute hour day month weekday second year`, and the field hint spells the order out
 - **Accepted cron expressions carrying random values or parameters** — `0 0 R * *` and `${params.schedule}` were rejected as invalid although the generator runs them; the field checked what could be spelled out in words rather than what the generator accepts. Both are accepted now, with a note under the field saying the schedule is resolved at run time
+- **Validated the HTTP output form against its own rules** — the form checked its values against the file output's rules instead, so a malformed URL or an out-of-range response code drew no inline error and surfaced only once the configuration was read
 
 #### Core
 

--- a/eventum/plugins/output/plugins/clickhouse/config.py
+++ b/eventum/plugins/output/plugins/clickhouse/config.py
@@ -57,7 +57,7 @@ class ClickhouseOutputPluginConfig(OutputPluginConfig, frozen=True):
         Client name that is prepended to the HTTP User Agent header,
         set this to track client queries in the ClickHouse query log.
 
-    verify : bool, default=False
+    verify : bool, default=True
         Whether to verify SSL certificate of ClickHouse server.
 
     ca_cert : Path | None, default=None

--- a/eventum/plugins/output/plugins/http/config.py
+++ b/eventum/plugins/output/plugins/http/config.py
@@ -45,7 +45,7 @@ class HttpOutputPluginConfig(OutputPluginConfig, frozen=True):
     request_timeout : int, default=300
         Requests timeout in seconds.
 
-    verify: bool, default=False
+    verify: bool, default=True
         Whether to verify SSL certificate of the server when
         connecting to it.
 
@@ -83,7 +83,7 @@ class HttpOutputPluginConfig(OutputPluginConfig, frozen=True):
     password: str | None = Field(default=None, min_length=1)
     connect_timeout: int = Field(default=10, ge=1)
     request_timeout: int = Field(default=300, ge=1)
-    verify: bool = Field(default=False)
+    verify: bool = Field(default=True)
     ca_cert: Path | None = Field(default=None)
     client_cert: Path | None = Field(default=None)
     client_cert_key: Path | None = Field(default=None)

--- a/eventum/plugins/output/plugins/http/tests/test_config.py
+++ b/eventum/plugins/output/plugins/http/tests/test_config.py
@@ -7,6 +7,21 @@ from eventum.plugins.output.plugins.http.config import (
 )
 
 
+def test_verify_is_enabled_by_default() -> None:
+    """Certificate verification is on when `verify` is omitted."""
+    config = HttpOutputPluginConfig(url='https://localhost:8080')
+    assert config.verify is True
+
+
+def test_verify_can_be_disabled() -> None:
+    """Certificate verification is off when `verify` is disabled."""
+    config = HttpOutputPluginConfig(
+        url='https://localhost:8080',
+        verify=False,
+    )
+    assert config.verify is False
+
+
 def test_ca_cert_accepts_path() -> None:
     """A `ca_cert` path is accepted and stored as a `Path`."""
     config = HttpOutputPluginConfig(

--- a/eventum/plugins/output/plugins/opensearch/config.py
+++ b/eventum/plugins/output/plugins/opensearch/config.py
@@ -39,7 +39,7 @@ class OpensearchOutputPluginConfig(OutputPluginConfig, frozen=True):
     request_timeout : int, default=300
         Requests timeout in seconds.
 
-    verify: bool, default=False
+    verify: bool, default=True
         Whether to verify SSL certificate of the cluster nodes when
         connecting to them.
 
@@ -67,7 +67,7 @@ class OpensearchOutputPluginConfig(OutputPluginConfig, frozen=True):
     index: str = Field(min_length=1)
     connect_timeout: int = Field(default=10, ge=1)
     request_timeout: int = Field(default=300, ge=1)
-    verify: bool = Field(default=False)
+    verify: bool = Field(default=True)
     ca_cert: Path | None = Field(default=None)
     client_cert: Path | None = Field(default=None)
     client_cert_key: Path | None = Field(default=None)

--- a/eventum/plugins/output/plugins/opensearch/tests/test_config.py
+++ b/eventum/plugins/output/plugins/opensearch/tests/test_config.py
@@ -7,6 +7,29 @@ from eventum.plugins.output.plugins.opensearch.config import (
 )
 
 
+def test_verify_is_enabled_by_default() -> None:
+    """Certificate verification is on when `verify` is omitted."""
+    config = OpensearchOutputPluginConfig(
+        hosts=['https://localhost:9200'],
+        index='i',
+        username='u',
+        password='p',  # noqa: S106
+    )
+    assert config.verify is True
+
+
+def test_verify_can_be_disabled() -> None:
+    """Certificate verification is off when `verify` is disabled."""
+    config = OpensearchOutputPluginConfig(
+        hosts=['https://localhost:9200'],
+        index='i',
+        username='u',
+        password='p',  # noqa: S106
+        verify=False,
+    )
+    assert config.verify is False
+
+
 def test_ca_cert_accepts_path() -> None:
     """A `ca_cert` path is accepted and stored as a `Path`."""
     config = OpensearchOutputPluginConfig(

--- a/eventum/ui/src/pages/ProjectPage/OutputPluginsTab/OutputPluginParams/HTTPOutputPluginParams.tsx
+++ b/eventum/ui/src/pages/ProjectPage/OutputPluginsTab/OutputPluginParams/HTTPOutputPluginParams.tsx
@@ -16,9 +16,9 @@ import { FC } from 'react';
 
 import { ProjectFileSelect } from '../../components/ProjectFileSelect';
 import { FormatterParams } from './components/FormatterParams';
-import { FileOutputPluginConfigSchema } from '@/api/routes/generator-configs/schemas/plugins/output/configs/file';
 import {
   HTTPOutputPluginConfig,
+  HTTPOutputPluginConfigSchema,
   HTTP_METHODS,
 } from '@/api/routes/generator-configs/schemas/plugins/output/configs/http';
 import { LabelWithTooltip } from '@/components/ui/LabelWithTooltip';
@@ -34,7 +34,7 @@ export const HTTPOutputPluginParams: FC<HTTPOutputPluginParamsProps> = ({
 }) => {
   const form = useForm<HTTPOutputPluginConfig>({
     initialValues: initialConfig,
-    validate: zod4Resolver(FileOutputPluginConfigSchema),
+    validate: zod4Resolver(HTTPOutputPluginConfigSchema),
     onValuesChange: onChange,
     validateInputOnChange: true,
   });


### PR DESCRIPTION
Closes #206

`verify` defaulted to `false` in the `opensearch` and `http` output configs, so a generator pointed at an `https://` endpoint accepted any certificate unless verification was requested explicitly. The value reaches `create_ssl_context`, which on a falsey value clears `check_hostname` and sets `CERT_NONE`. The `clickhouse` and `tcp` outputs default to `true`, so the same connection was checked in one plugin and unchecked in another.

## Changes

- `verify` now defaults to `true` in both configs, with the docstrings following.
- The `clickhouse` docstring carried the same mismatch in the other direction — it documented `false` while the field had been `true`.
- Separately: the HTTP output form in Studio validated its values against the file output's schema, so `url`, `success_code` and the timeouts went unchecked and a `path` error was reported on a field the form does not render.

## Behaviour change

A generator writing to an endpoint with a self-signed or internal-CA certificate and no explicit `verify` now fails with a certificate error instead of connecting. The remedy is `ca_cert` pointed at the issuing CA, or `verify: false` to keep the connection unchecked. A plain `http://` target never performs a handshake, so nothing changes there.

No generator in `content-packs` uses these outputs. The opensearch integration tests set `verify=False` explicitly and are unaffected.

## Verification

`ruff check`, `ruff format --check`, `mypy` (448 files), `pytest` (1506 passed), `tsc -b`, `vite build` — all green.

Docs: eventum-generator/docs#53