### PR TITLE
fix(ui): match the plugin switches to the generator's defaults

### DIFF
--- a/.claude/rules/backend/plugins.md
+++ b/.claude/rules/backend/plugins.md
@@ -43,3 +43,4 @@ eventum/plugins/<type>/plugins/<name>/
 
 - Any user-facing change - new plugin or config field change - must be mirrored in the UI (Zod schema + form) and docs (MDX page). See `frontend/ui.md` "Plugin UI" and `docs/mdx.md` rules.
 - Plugin configs are part of the generator-config API models, so a config change also changes the published OpenAPI schema. Re-export it as described in `backend/api.md` "OpenAPI export".
+- Changing a field **default** is a UI change too. A configuration is read back without its unset fields, so Studio never receives the default - a form that shows it holds its own copy. Update the `checked` fallback of the matching switch and any tooltip that spells the default out, or the form will keep stating the old value.

--- a/.claude/rules/frontend/ui.md
+++ b/.claude/rules/frontend/ui.md
@@ -49,6 +49,7 @@ Adding or modifying a plugin touches four places.
 - Wire inputs via `@mantine/form` + `zod4Resolver` so Zod errors surface as field errors.
 - Forms propagate changes through a parent `onChange` callback, not a submit.
 - Empty inputs for optional fields must land as `undefined`, not empty strings.
+- A `Switch` has no "unset" state, and configurations arrive without their unset fields. Set `checked` to fall back to the backend default, otherwise a field the user never touched is drawn as off whatever the plugin does.
 - For validation that only makes sense in the UI (e.g. friendlier error messages), extend the schema inside the form component. Don't touch the canonical schema under `api/routes/`.
 
 ## Editor autocomplete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 - **Read the cron seconds field in the generator's order** — the text under the cron Expression field took the seconds as the first field, so `35 10 * * * 3` was described as "At 35 seconds past the minute … only on Wednesday" while the generator fires at 10:35:03 every day. The description and the validity check now follow `minute hour day month weekday second year`, and the field hint spells the order out
 - **Accepted cron expressions carrying random values or parameters** — `0 0 R * *` and `${params.schedule}` were rejected as invalid although the generator runs them; the field checked what could be spelled out in words rather than what the generator accepts. Both are accepted now, with a note under the field saying the schedule is resolved at run time
 - **Validated the HTTP output form against its own rules** — the form checked its values against the file output's rules instead, so a malformed URL or an out-of-range response code drew no inline error and surfaced only once the configuration was read
+- **Matched the plugin switches to the generator's defaults** — a field the configuration does not mention was drawn as off, so Verify SSL on the `http`, `opensearch`, `clickhouse` and `tcp` outputs read as unchecked while the generator was verifying the certificate, and Include end point on the `linspace` input read as off while the range included it. A switch now shows what the field resolves to, and an untouched field is still left out of the configuration
 
 #### Core
 

--- a/eventum/ui/src/pages/ProjectPage/InputPluginsTab/InputPluginParams/LinspaceInputPluginParams.tsx
+++ b/eventum/ui/src/pages/ProjectPage/InputPluginsTab/InputPluginParams/LinspaceInputPluginParams.tsx
@@ -101,6 +101,11 @@ export const LinspaceInputPluginParams: FC<LinspaceInputPluginParamsProps> = ({
           />
         }
         {...form.getInputProps('endpoint', { type: 'checkbox' })}
+        checked={
+          typeof form.values.endpoint === 'boolean'
+            ? form.values.endpoint
+            : true
+        }
       />
 
       <TagsInput

--- a/eventum/ui/src/pages/ProjectPage/OutputPluginsTab/OutputPluginParams/ClickhouseOutputPluginParams.tsx
+++ b/eventum/ui/src/pages/ProjectPage/OutputPluginsTab/OutputPluginParams/ClickhouseOutputPluginParams.tsx
@@ -302,6 +302,11 @@ export const ClickhouseOutputPluginParams: FC<
               />
             }
             {...form.getInputProps('verify', { type: 'checkbox' })}
+            checked={
+              typeof form.values.verify === 'boolean'
+                ? form.values.verify
+                : true
+            }
           />
 
           <ProjectFileSelect

--- a/eventum/ui/src/pages/ProjectPage/OutputPluginsTab/OutputPluginParams/HTTPOutputPluginParams.tsx
+++ b/eventum/ui/src/pages/ProjectPage/OutputPluginsTab/OutputPluginParams/HTTPOutputPluginParams.tsx
@@ -219,6 +219,11 @@ export const HTTPOutputPluginParams: FC<HTTPOutputPluginParamsProps> = ({
               />
             }
             {...form.getInputProps('verify', { type: 'checkbox' })}
+            checked={
+              typeof form.values.verify === 'boolean'
+                ? form.values.verify
+                : true
+            }
           />
 
           <ProjectFileSelect

--- a/eventum/ui/src/pages/ProjectPage/OutputPluginsTab/OutputPluginParams/OpensearchOutputPluginParams.tsx
+++ b/eventum/ui/src/pages/ProjectPage/OutputPluginsTab/OutputPluginParams/OpensearchOutputPluginParams.tsx
@@ -187,6 +187,11 @@ export const OpensearchOutputPluginParams: FC<
               />
             }
             {...form.getInputProps('verify', { type: 'checkbox' })}
+            checked={
+              typeof form.values.verify === 'boolean'
+                ? form.values.verify
+                : true
+            }
           />
 
           <ProjectFileSelect

--- a/eventum/ui/src/pages/ProjectPage/OutputPluginsTab/OutputPluginParams/TcpOutputPluginParams.tsx
+++ b/eventum/ui/src/pages/ProjectPage/OutputPluginsTab/OutputPluginParams/TcpOutputPluginParams.tsx
@@ -202,6 +202,11 @@ export const TcpOutputPluginParams: FC<TcpOutputPluginParamsProps> = ({
               }
               disabled={!form.getValues().ssl}
               {...form.getInputProps('verify', { type: 'checkbox' })}
+              checked={
+                typeof form.values.verify === 'boolean'
+                  ? form.values.verify
+                  : true
+              }
             />
           </Group>
 


### PR DESCRIPTION
Closes #210

**Stacked on #209** — until that merges, the diff here also carries its two commits. Review `e4e58845`, or merge #209 first.

A configuration is read back with `response_model_exclude_unset=True`, so Studio never sees the fields the user did not write. A text input renders empty, which honestly reads as "not set"; a `Switch` has no empty state and rendered as **off** whatever the plugin actually does:

| Plugin | Field | Backend default |
|---|---|---|
| `http` output | `verify` | `true` |
| `opensearch` output | `verify` | `true` |
| `clickhouse` output | `verify` | `true` |
| `tcp` output | `verify` | `true` |
| `linspace` input | `endpoint` | `true` |

The four `verify` switches were the damaging ones: the form said certificates were not checked while the generator was checking them.

Each switch now falls back to the plugin's declared default when the field is unset. An untouched field stays absent from the form values, so it is still not written to `generator.yml` — only the display changes. A field holding a `${params.*}` placeholder, reachable only by hand-editing the YAML, falls back the same way instead of reading as on by virtue of being a non-empty string.

## Note on approach

An earlier revision of this branch derived these values from the Python configs through a generated artifact and a drift-guard test. That was dropped: the one thing build-time generation buys — a UI that does not need the server — is worth nothing in Studio, which cannot render a project page without it. Five rarely-changing booleans do not justify a regeneration ritual, a committed artifact and a guard test.

Nothing detects the two copies disagreeing, so the seam is written down on both sides: `.claude/rules/backend/plugins.md` states that changing a default is a UI change, and `.claude/rules/frontend/ui.md` states that a switch must carry the default itself.

The real duplication is elsewhere: ~1280 lines of hand-mirrored Zod schemas under `api/routes/generator-configs/schemas/`. Generating those from the OpenAPI document is the change that would remove this class of drift, and `api_types.py` already encodes `orPlaceholder` as `anyOf: [T, string]` there. Out of scope here.

## Verification

`tsc -b`, `eslint`, `prettier --check`, `vitest` (41 passed), `vite build` — all green. No Python changed on top of #209, so the backend checks are unaffected.