### PR TITLE
fix(ui): configure the editor once per opened file

### DIFF
--- a/.claude/rules/frontend/ui.md
+++ b/.claude/rules/frontend/ui.md
@@ -55,3 +55,12 @@ Adding or modifying a plugin touches four places.
 
 - `globals.ts` under `pages/ProjectPage/common/EditorTab/FileEditor/completions/` is the single source for Jinja template autocomplete.
 - Mirror there any backend change that exposes new template context variables or module functions.
+
+## Tests
+
+`pnpm test` runs vitest over `src/**/*.test.{ts,tsx}` in jsdom. Tests sit next to the code they cover.
+
+- `src/test/setup.ts` - jest-dom matchers, unmount after each test, and the jsdom stubs the app mounts against (`matchMedia`, `ResizeObserver`, `IntersectionObserver`).
+- `src/test/render.tsx` - `renderWithProviders` mounts a component under the app theme and a query client of its own; page-specific providers are wrapped at the call site.
+- Data comes from mocking the `api/hooks/` module the component reads - tests never reach the network.
+- Drive interaction through `@testing-library/user-event`. Nothing in jsdom is laid out, so anything resting on real geometry belongs in a browser instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ All notable changes to this project will be documented in this file.
 - **Served a generator file as a snapshot of the moment it was requested** — reading an output file of a running generator aborted mid-response, because the response declared the file size before reading the file and the file kept growing. A file that cannot be read now answers with an error instead of a dropped connection
 - **Moved the scenario global-state scan to a worker thread** — a scenario with many generators opens instead of hanging and failing after about ten seconds
 
+### ⚡ Performance
+
+- **Stopped rebuilding the editor configuration on every keystroke** — typing in a project file rebuilt the editor's language mode, autocomplete, search and save shortcut on each character, which told on a large file. The configuration is now built once per opened file
+
 ### 🧪 Testing
 
 - **Added a component-test harness to Eventum Studio** — the UI suite runs in jsdom with React Testing Library, so a screen or a control can be mounted and driven from a test instead of only its pure helpers being covered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ All notable changes to this project will be documented in this file.
 - **Served a generator file as a snapshot of the moment it was requested** — reading an output file of a running generator aborted mid-response, because the response declared the file size before reading the file and the file kept growing. A file that cannot be read now answers with an error instead of a dropped connection
 - **Moved the scenario global-state scan to a worker thread** — a scenario with many generators opens instead of hanging and failing after about ten seconds
 
+### 🧪 Testing
+
+- **Added a component-test harness to Eventum Studio** — the UI suite runs in jsdom with React Testing Library, so a screen or a control can be mounted and driven from a test instead of only its pure helpers being covered
+
 ### 📝 Other Changes
 
 - **Nested the `server.ui` and `server.api` config sections** — the web UI and REST API toggles moved under `server.ui.enabled` and `server.api.enabled`, matching `server.mcp`. The flat `server.ui_enabled` and `server.api_enabled` keys still work but are deprecated, warn at startup and go away in 2.8; mixing a flat key with its nested form is rejected

--- a/eventum/ui/package.json
+++ b/eventum/ui/package.json
@@ -8,6 +8,8 @@
     "build": "tsc -b && vite build --config vite.config.ts",
     "lint": "eslint .",
     "lint:css": "stylelint \"src/**/*.css\"",
+    "format": "prettier --write \"src/**/*.{ts,tsx,css}\" \"*.ts\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\" \"*.ts\"",
     "test": "vitest run",
     "preview": "vite preview"
   },

--- a/eventum/ui/package.json
+++ b/eventum/ui/package.json
@@ -62,6 +62,10 @@
   "devDependencies": {
     "@eslint/js": "^9.30.0",
     "@tanstack/react-query-devtools": "^5.90.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@types/bytes": "^3.1.5",
     "@types/lodash": "^4.17.23",
@@ -84,6 +88,7 @@
     "eslint-plugin-sonarjs": "^3.0.4",
     "eslint-plugin-unicorn": "^60.0.0",
     "globals": "^16.2.0",
+    "jsdom": "^30.0.0",
     "postcss": "^8.5.6",
     "postcss-preset-mantine": "^1.18.0",
     "postcss-simple-vars": "^7.0.1",

--- a/eventum/ui/pnpm-lock.yaml
+++ b/eventum/ui/pnpm-lock.yaml
@@ -153,6 +153,18 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: ^5.90.2
         version: 5.94.5(@tanstack/react-query@5.94.5(react@19.2.4))(react@19.2.4)
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^7.0.0
+        version: 7.0.0(@testing-library/dom@10.4.1)
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^5.2.2
         version: 5.2.2(prettier@3.8.1)
@@ -219,6 +231,9 @@ importers:
       globals:
         specifier: ^16.2.0
         version: 16.5.0
+      jsdom:
+        specifier: ^30.0.0
+        version: 30.0.0
       postcss:
         specifier: ^8.5.6
         version: 8.5.8
@@ -251,9 +266,20 @@ importers:
         version: 4.5.0(rollup@4.59.1)(typescript@5.8.3)(vite@7.3.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(yaml@2.8.3))
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.12.0)(vite@7.3.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(yaml@2.8.3))
+        version: 4.1.10(@types/node@24.12.0)(jsdom@30.0.0)(vite@7.3.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(yaml@2.8.3))
 
 packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@asamuzakjp/css-color@6.0.5':
+    resolution: {integrity: sha512-mbhpPMmnw/kwW19aRNmSUl1QzLbdGo1SCuE49BT98MNwqF6zaHb3o2owssFc/PEO/4t2UjqtCNwocuDtJornzA==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.0':
+    resolution: {integrity: sha512-UJLfKXBhrc8i1vH2eJXuYQMwlsLKWFw3O+CPqXSuVEiikeAim3UgrfWX0k4tA/X8cRFM8iZ7OaqBokFGbYusdg==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -342,6 +368,10 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@cacheable/memory@2.2.0':
     resolution: {integrity: sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==}
 
@@ -396,8 +426,26 @@ packages:
   '@codemirror/view@6.40.0':
     resolution: {integrity: sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==}
 
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
   '@csstools/css-calc@3.2.1':
     resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.10':
+    resolution: {integrity: sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
@@ -650,6 +698,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -1142,6 +1199,37 @@ packages:
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@7.0.0':
+    resolution: {integrity: sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==}
+    engines: {node: '>=22', npm: '>=6', yarn: '>=1'}
+    peerDependencies:
+      '@testing-library/dom': '>=10 <11'
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@trivago/prettier-plugin-sort-imports@5.2.2':
     resolution: {integrity: sha512-fYDQA9e6yTNmA13TLVSA+WMQRc5Bn/c0EUBditUHNfMMxN7M82c38b1kEggVE3pLpZ0FwkwJkUEKMiOi52JXFA==}
     engines: {node: '>18.12'}
@@ -1160,6 +1248,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1528,8 +1619,15 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1614,6 +1712,9 @@ packages:
     resolution: {integrity: sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -1778,6 +1879,9 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -1855,6 +1959,10 @@ packages:
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -1890,6 +1998,9 @@ packages:
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1919,6 +2030,12 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
@@ -1941,6 +2058,10 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -2372,6 +2493,10 @@ packages:
   hookified@2.2.0:
     resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-tags@5.1.0:
     resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
     engines: {node: '>=20.10'}
@@ -2403,6 +2528,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
@@ -2501,6 +2630,9 @@ packages:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -2556,6 +2688,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@30.0.0:
+    resolution: {integrity: sha512-JQHfRGmmKmaZoUAvIgff5jjG/0SzTQlGz8c7t72KzBzo8ZULEjAjnYE0sNwBOUA4QtWwYE2xoYitg8NFsmiYxA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
@@ -2647,8 +2788,16 @@ packages:
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2716,6 +2865,10 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.1.2:
     resolution: {integrity: sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==}
@@ -2837,6 +2990,9 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2936,6 +3092,10 @@ packages:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
     hasBin: true
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -3066,6 +3226,10 @@ packages:
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
@@ -3154,6 +3318,10 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3298,6 +3466,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-indent@4.1.1:
     resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
     engines: {node: '>=12'}
@@ -3348,6 +3520,9 @@ packages:
   svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
@@ -3373,9 +3548,24 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.9:
+    resolution: {integrity: sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==}
+
+  tldts@7.4.9:
+    resolution: {integrity: sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -3434,6 +3624,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+    engines: {node: '>=22.19.0'}
 
   unicorn-magic@0.4.0:
     resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
@@ -3623,6 +3817,26 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -3661,6 +3875,13 @@ packages:
     resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -3695,6 +3916,23 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@adobe/css-tools@4.5.0': {}
+
+  '@asamuzakjp/css-color@6.0.5':
+    dependencies:
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.0':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3809,6 +4047,10 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
 
   '@cacheable/memory@2.2.0':
     dependencies:
@@ -3946,8 +4188,22 @@ snapshots:
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
 
+  '@csstools/color-helpers@6.1.0': {}
+
   '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
@@ -4122,6 +4378,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -4576,6 +4834,41 @@ snapshots:
 
   '@tanstack/table-core@8.21.3': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      '@testing-library/dom': 10.4.1
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@trivago/prettier-plugin-sort-imports@5.2.2(prettier@3.8.1)':
     dependencies:
       '@babel/generator': 7.29.1
@@ -4592,6 +4885,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -4993,7 +5288,13 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -5099,6 +5400,10 @@ snapshots:
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.10: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   brace-expansion@1.1.12:
     dependencies:
@@ -5254,6 +5559,8 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
@@ -5324,6 +5631,13 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -5354,6 +5668,8 @@ snapshots:
 
   decimal.js-light@2.5.1: {}
 
+  decimal.js@10.6.0: {}
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -5382,6 +5698,10 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dom-helpers@5.2.1:
     dependencies:
       '@babel/runtime': 7.29.2
@@ -5405,6 +5725,8 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   entities@4.5.0: {}
+
+  entities@8.0.0: {}
 
   env-paths@2.2.1: {}
 
@@ -6006,6 +6328,12 @@ snapshots:
 
   hookified@2.2.0: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-tags@5.1.0: {}
 
   html-void-elements@3.0.0: {}
@@ -6026,6 +6354,8 @@ snapshots:
   import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   indent-string@5.0.0: {}
 
@@ -6122,6 +6452,8 @@ snapshots:
 
   is-path-inside@4.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -6181,6 +6513,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@30.0.0:
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.5
+      '@asamuzakjp/dom-selector': 8.3.0
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.9.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.0.2: {}
 
@@ -6254,9 +6612,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -6324,6 +6686,8 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  min-indent@1.0.1: {}
 
   minimatch@10.1.2:
     dependencies:
@@ -6453,6 +6817,10 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -6532,6 +6900,12 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@3.8.1: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   prop-types@15.8.1:
     dependencies:
@@ -6660,6 +7034,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - redux
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
@@ -6790,6 +7169,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -6980,6 +7363,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-indent@4.1.1: {}
 
   strip-json-comments@3.1.1: {}
@@ -7052,6 +7439,8 @@ snapshots:
 
   svg-tags@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tabbable@6.4.0: {}
 
   table@6.9.0:
@@ -7075,9 +7464,23 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.4.9: {}
+
+  tldts@7.4.9:
+    dependencies:
+      tldts-core: 7.4.9
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.9
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -7154,6 +7557,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@7.16.0: {}
+
+  undici@8.9.0: {}
 
   unicorn-magic@0.4.0: {}
 
@@ -7308,7 +7713,7 @@ snapshots:
       sugarss: 5.0.1(postcss@8.5.8)
       yaml: 2.8.3
 
-  vitest@4.1.10(@types/node@24.12.0)(vite@7.3.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(yaml@2.8.3)):
+  vitest@4.1.10(@types/node@24.12.0)(jsdom@30.0.0)(vite@7.3.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@7.3.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(yaml@2.8.3))
@@ -7332,10 +7737,35 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.0
+      jsdom: 30.0.0
     transitivePeerDependencies:
       - msw
 
   w3c-keyname@2.2.8: {}
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -7396,6 +7826,10 @@ snapshots:
   write-file-atomic@7.0.1:
     dependencies:
       signal-exit: 4.1.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/eventum/ui/src/api/hooks/useScenarios.ts
+++ b/eventum/ui/src/api/hooks/useScenarios.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 
 import {
   addGeneratorToScenario,
@@ -59,8 +64,13 @@ export function useAddGeneratorToScenarioMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ name, generatorId }: { name: string; generatorId: string }) =>
-      addGeneratorToScenario(name, generatorId),
+    mutationFn: ({
+      name,
+      generatorId,
+    }: {
+      name: string;
+      generatorId: string;
+    }) => addGeneratorToScenario(name, generatorId),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: SCENARIOS_QUERY_KEY,
@@ -76,8 +86,13 @@ export function useRemoveGeneratorFromScenarioMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ name, generatorId }: { name: string; generatorId: string }) =>
-      removeGeneratorFromScenario(name, generatorId),
+    mutationFn: ({
+      name,
+      generatorId,
+    }: {
+      name: string;
+      generatorId: string;
+    }) => removeGeneratorFromScenario(name, generatorId),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: SCENARIOS_QUERY_KEY,

--- a/eventum/ui/src/api/routes/generator-configs/index.ts
+++ b/eventum/ui/src/api/routes/generator-configs/index.ts
@@ -13,7 +13,7 @@ import {
   GeneratorFileContentSchema,
   GeneratorIdsSchema,
 } from './schemas';
-import { apiClient, TRANSFER_TIMEOUT } from '@/api/client';
+import { TRANSFER_TIMEOUT, apiClient } from '@/api/client';
 import '@/api/routes/instance/schemas';
 import { validateResponse } from '@/api/wrappers';
 

--- a/eventum/ui/src/api/routes/generator-configs/modules/plugins/registry.ts
+++ b/eventum/ui/src/api/routes/generator-configs/modules/plugins/registry.ts
@@ -48,14 +48,15 @@ import { UdpOutputPluginDefaultConfig } from './default-configs/output/udp';
 
 /** Scale down filled brand icons to visually match stroked Tabler icons. */
 function brandIcon(BaseIcon: IconType): IconType {
-  const Scaled = forwardRef<SVGSVGElement, React.ComponentPropsWithoutRef<IconType>>(
-    ({ size, ...rest }, ref) =>
-      createElement(BaseIcon, {
-        ...rest,
-        ref,
-        size:
-          typeof size === 'number' ? Math.round(size * 0.82) : size,
-      }),
+  const Scaled = forwardRef<
+    SVGSVGElement,
+    React.ComponentPropsWithoutRef<IconType>
+  >(({ size, ...rest }, ref) =>
+    createElement(BaseIcon, {
+      ...rest,
+      ref,
+      size: typeof size === 'number' ? Math.round(size * 0.82) : size,
+    })
   );
   Scaled.displayName = `BrandIcon(${BaseIcon.displayName ?? 'Icon'})`;
   return Scaled;

--- a/eventum/ui/src/api/routes/generator-configs/schemas/plugins/event/configs/replay.ts
+++ b/eventum/ui/src/api/routes/generator-configs/schemas/plugins/event/configs/replay.ts
@@ -1,7 +1,7 @@
 import z from 'zod';
 
-import { orPlaceholder } from '../../../placeholder';
 import { ENCODINGS } from '../../../encodings';
+import { orPlaceholder } from '../../../placeholder';
 import { BaseEventPluginConfigSchema } from '../base-config';
 
 export const ReplayEventPluginConfigSchema = BaseEventPluginConfigSchema.extend(

--- a/eventum/ui/src/api/routes/generator-configs/schemas/plugins/output/configs/file.ts
+++ b/eventum/ui/src/api/routes/generator-configs/schemas/plugins/output/configs/file.ts
@@ -1,7 +1,7 @@
 import z from 'zod';
 
-import { orPlaceholder } from '../../../placeholder';
 import { ENCODINGS } from '../../../encodings';
+import { orPlaceholder } from '../../../placeholder';
 import { BaseOutputPluginConfigSchema } from '../base-config';
 
 export const WRITE_MODES = ['append', 'overwrite'] as const;

--- a/eventum/ui/src/api/routes/generator-configs/schemas/plugins/output/configs/kafka.ts
+++ b/eventum/ui/src/api/routes/generator-configs/schemas/plugins/output/configs/kafka.ts
@@ -1,7 +1,7 @@
 import z from 'zod';
 
-import { orPlaceholder } from '../../../placeholder';
 import { ENCODINGS } from '../../../encodings';
+import { orPlaceholder } from '../../../placeholder';
 import { BaseOutputPluginConfigSchema } from '../base-config';
 
 export const SECURITY_PROTOCOLS = [
@@ -17,12 +17,7 @@ export const SASL_MECHANISMS = [
   'SCRAM-SHA-512',
 ] as const;
 
-export const COMPRESSION_TYPES = [
-  'gzip',
-  'snappy',
-  'lz4',
-  'zstd',
-] as const;
+export const COMPRESSION_TYPES = ['gzip', 'snappy', 'lz4', 'zstd'] as const;
 
 export const ACKS_VALUES = [0, 1, -1] as const;
 
@@ -41,14 +36,12 @@ export const KafkaOutputPluginConfigSchema =
     encoding: orPlaceholder(z.enum(ENCODINGS)).optional(),
 
     // Performance & Reliability
-    acks: orPlaceholder(z.union([
-      z.literal(0),
-      z.literal(1),
-      z.literal(-1),
-    ])).optional(),
-    compression_type: orPlaceholder(
-      z.enum(COMPRESSION_TYPES),
-    ).nullable().optional(),
+    acks: orPlaceholder(
+      z.union([z.literal(0), z.literal(1), z.literal(-1)])
+    ).optional(),
+    compression_type: orPlaceholder(z.enum(COMPRESSION_TYPES))
+      .nullable()
+      .optional(),
     max_batch_size: orPlaceholder(z.number().int().gte(1)).optional(),
     max_request_size: orPlaceholder(z.number().int().gte(1)).optional(),
     linger_ms: orPlaceholder(z.number().int().gte(0)).optional(),
@@ -58,12 +51,10 @@ export const KafkaOutputPluginConfigSchema =
     transaction_timeout_ms: orPlaceholder(z.number().int().gte(1)).optional(),
 
     // Security
-    security_protocol: orPlaceholder(
-      z.enum(SECURITY_PROTOCOLS),
-    ).optional(),
-    sasl_mechanism: orPlaceholder(
-      z.enum(SASL_MECHANISMS),
-    ).nullable().optional(),
+    security_protocol: orPlaceholder(z.enum(SECURITY_PROTOCOLS)).optional(),
+    sasl_mechanism: orPlaceholder(z.enum(SASL_MECHANISMS))
+      .nullable()
+      .optional(),
     sasl_plain_username: z.string().min(1).nullable().optional(),
     sasl_plain_password: z.string().min(1).nullable().optional(),
     sasl_kerberos_service_name: z.string().min(1).optional(),

--- a/eventum/ui/src/api/routes/generator-configs/schemas/plugins/output/configs/stdout.ts
+++ b/eventum/ui/src/api/routes/generator-configs/schemas/plugins/output/configs/stdout.ts
@@ -1,7 +1,7 @@
 import z from 'zod';
 
-import { orPlaceholder } from '../../../placeholder';
 import { ENCODINGS } from '../../../encodings';
+import { orPlaceholder } from '../../../placeholder';
 import { BaseOutputPluginConfigSchema } from '../base-config';
 
 export const StdoutOutputPluginConfigSchema =

--- a/eventum/ui/src/api/routes/generator-configs/schemas/plugins/output/configs/tcp.ts
+++ b/eventum/ui/src/api/routes/generator-configs/schemas/plugins/output/configs/tcp.ts
@@ -1,25 +1,22 @@
 import z from 'zod';
 
-import { orPlaceholder } from '../../../placeholder';
 import { ENCODINGS } from '../../../encodings';
+import { orPlaceholder } from '../../../placeholder';
 import { BaseOutputPluginConfigSchema } from '../base-config';
 
-export const TcpOutputPluginConfigSchema =
-  BaseOutputPluginConfigSchema.extend({
-    host: z.string().min(1),
-    port: orPlaceholder(z.number().int().gte(1).lte(65_535)),
-    encoding: orPlaceholder(z.enum(ENCODINGS)).optional(),
-    separator: z.string().optional(),
-    connect_timeout: orPlaceholder(z.number().int().gte(1)).optional(),
-    ssl: orPlaceholder(z.boolean()).optional(),
-    verify: orPlaceholder(z.boolean()).optional(),
-    ca_cert: z.string().min(1).nullable().optional(),
-    client_cert: z.string().min(1).nullable().optional(),
-    client_cert_key: z.string().min(1).nullable().optional(),
-  });
-export type TcpOutputPluginConfig = z.infer<
-  typeof TcpOutputPluginConfigSchema
->;
+export const TcpOutputPluginConfigSchema = BaseOutputPluginConfigSchema.extend({
+  host: z.string().min(1),
+  port: orPlaceholder(z.number().int().gte(1).lte(65_535)),
+  encoding: orPlaceholder(z.enum(ENCODINGS)).optional(),
+  separator: z.string().optional(),
+  connect_timeout: orPlaceholder(z.number().int().gte(1)).optional(),
+  ssl: orPlaceholder(z.boolean()).optional(),
+  verify: orPlaceholder(z.boolean()).optional(),
+  ca_cert: z.string().min(1).nullable().optional(),
+  client_cert: z.string().min(1).nullable().optional(),
+  client_cert_key: z.string().min(1).nullable().optional(),
+});
+export type TcpOutputPluginConfig = z.infer<typeof TcpOutputPluginConfigSchema>;
 export const TcpOutputPluginNamedConfigSchema = z.object({
   tcp: TcpOutputPluginConfigSchema,
 });

--- a/eventum/ui/src/api/routes/generator-configs/schemas/plugins/output/configs/udp.ts
+++ b/eventum/ui/src/api/routes/generator-configs/schemas/plugins/output/configs/udp.ts
@@ -1,19 +1,16 @@
 import z from 'zod';
 
-import { orPlaceholder } from '../../../placeholder';
 import { ENCODINGS } from '../../../encodings';
+import { orPlaceholder } from '../../../placeholder';
 import { BaseOutputPluginConfigSchema } from '../base-config';
 
-export const UdpOutputPluginConfigSchema =
-  BaseOutputPluginConfigSchema.extend({
-    host: z.string().min(1),
-    port: orPlaceholder(z.number().int().gte(1).lte(65_535)),
-    encoding: orPlaceholder(z.enum(ENCODINGS)).optional(),
-    separator: z.string().optional(),
-  });
-export type UdpOutputPluginConfig = z.infer<
-  typeof UdpOutputPluginConfigSchema
->;
+export const UdpOutputPluginConfigSchema = BaseOutputPluginConfigSchema.extend({
+  host: z.string().min(1),
+  port: orPlaceholder(z.number().int().gte(1).lte(65_535)),
+  encoding: orPlaceholder(z.enum(ENCODINGS)).optional(),
+  separator: z.string().optional(),
+});
+export type UdpOutputPluginConfig = z.infer<typeof UdpOutputPluginConfigSchema>;
 export const UdpOutputPluginNamedConfigSchema = z.object({
   udp: UdpOutputPluginConfigSchema,
 });

--- a/eventum/ui/src/api/routes/scenarios/index.ts
+++ b/eventum/ui/src/api/routes/scenarios/index.ts
@@ -1,10 +1,9 @@
 import z from 'zod';
 
 import { GlobalsUsageSchema, ScenarioResponseSchema } from './schemas';
+import type { GlobalsUsage, ScenarioResponse } from './schemas';
 import { apiClient } from '@/api/client';
 import { validateResponse } from '@/api/wrappers';
-
-import type { GlobalsUsage, ScenarioResponse } from './schemas';
 
 export async function listScenarios(): Promise<string[]> {
   return await validateResponse(

--- a/eventum/ui/src/components/layout/AppLayout/Header/AboutModal.tsx
+++ b/eventum/ui/src/components/layout/AppLayout/Header/AboutModal.tsx
@@ -10,11 +10,7 @@ import {
   Title,
 } from '@mantine/core';
 import { modals } from '@mantine/modals';
-import {
-  IconBox,
-  IconBrandPython,
-  IconServer,
-} from '@tabler/icons-react';
+import { IconBox, IconBrandPython, IconServer } from '@tabler/icons-react';
 import { FC } from 'react';
 
 import { useInstanceInfo } from '@/api/hooks/useInstance';

--- a/eventum/ui/src/components/layout/AppLayout/Navbar/data.ts
+++ b/eventum/ui/src/components/layout/AppLayout/Navbar/data.ts
@@ -4,10 +4,10 @@ import {
   IconBug,
   IconFolder,
   IconLock,
-  IconTransform,
   IconPlayerPlay,
   IconServerCog,
   IconSettings,
+  IconTransform,
   IconUsersGroup,
 } from '@tabler/icons-react';
 

--- a/eventum/ui/src/pages/InstancesPage/CreateInstanceModal.tsx
+++ b/eventum/ui/src/pages/InstancesPage/CreateInstanceModal.tsx
@@ -82,7 +82,12 @@ export const CreateInstanceModal: FC<CreateInstanceModalProps> = ({
                 addGeneratorToStartup.mutate(
                   {
                     id: values.id,
-                    params: { ...values, path: resolvedPath, autostart: false, scenarios: [] },
+                    params: {
+                      ...values,
+                      path: resolvedPath,
+                      autostart: false,
+                      scenarios: [],
+                    },
                   },
                   {
                     onSuccess: () => {

--- a/eventum/ui/src/pages/InstancesPage/InstancesTable/metrics/utils/layoutNodes.ts
+++ b/eventum/ui/src/pages/InstancesPage/InstancesTable/metrics/utils/layoutNodes.ts
@@ -1,10 +1,14 @@
-import { MarkerType, type Edge, type Node } from '@xyflow/react';
+import { type Edge, MarkerType, type Node } from '@xyflow/react';
 
 import type { GeneratorStats } from '@/api/routes/generators/schemas';
 
 export const NODE_WIDTH = 250;
 const COLUMN_GAP = 120;
-const COLUMN_X = [0, NODE_WIDTH + COLUMN_GAP, (NODE_WIDTH + COLUMN_GAP) * 2] as const;
+const COLUMN_X = [
+  0,
+  NODE_WIDTH + COLUMN_GAP,
+  (NODE_WIDTH + COLUMN_GAP) * 2,
+] as const;
 
 /** Fixed Y offset of edge handles from node top — all handles share this offset. */
 export const HANDLE_Y = 20;
@@ -28,7 +32,10 @@ export interface PipelineNodeData extends Record<string, unknown> {
 function layoutColumn(count: number, anchorY: number): number[] {
   const span = (count - 1) * NODE_SPACING_Y;
   const firstAnchor = anchorY - span / 2;
-  return Array.from({ length: count }, (_, i) => firstAnchor + i * NODE_SPACING_Y - HANDLE_Y);
+  return Array.from(
+    { length: count },
+    (_, i) => firstAnchor + i * NODE_SPACING_Y - HANDLE_Y
+  );
 }
 
 const EDGE_STYLE = {
@@ -85,7 +92,11 @@ export function buildNodes(stats: GeneratorStats): Node<PipelineNodeData>[] {
       metrics: [
         { label: 'Produced', value: stats.event.produced },
         { label: 'Dropped', value: stats.event.dropped },
-        { label: 'Produce failed', value: stats.event.produce_failed, isError: stats.event.produce_failed > 0 },
+        {
+          label: 'Produce failed',
+          value: stats.event.produce_failed,
+          isError: stats.event.produce_failed > 0,
+        },
       ],
       colorType: 'event',
     },
@@ -102,8 +113,16 @@ export function buildNodes(stats: GeneratorStats): Node<PipelineNodeData>[] {
         pluginId: plugin.plugin_id,
         metrics: [
           { label: 'Written', value: plugin.written },
-          { label: 'Format failed', value: plugin.format_failed, isError: plugin.format_failed > 0 },
-          { label: 'Write failed', value: plugin.write_failed, isError: plugin.write_failed > 0 },
+          {
+            label: 'Format failed',
+            value: plugin.format_failed,
+            isError: plugin.format_failed > 0,
+          },
+          {
+            label: 'Write failed',
+            value: plugin.write_failed,
+            isError: plugin.write_failed > 0,
+          },
         ],
         colorType: 'output',
       },
@@ -149,7 +168,7 @@ export function buildEdges(stats: GeneratorStats): Edge[] {
 /** Update only metrics inside existing nodes — positions untouched. */
 export function updateNodesData(
   nodes: Node<PipelineNodeData>[],
-  stats: GeneratorStats,
+  stats: GeneratorStats
 ): Node<PipelineNodeData>[] {
   return nodes.map((node) => {
     const { data } = node;
@@ -174,7 +193,11 @@ export function updateNodesData(
             metrics: [
               { label: 'Produced', value: stats.event.produced },
               { label: 'Dropped', value: stats.event.dropped },
-              { label: 'Produce failed', value: stats.event.produce_failed, isError: stats.event.produce_failed > 0 },
+              {
+                label: 'Produce failed',
+                value: stats.event.produce_failed,
+                isError: stats.event.produce_failed > 0,
+              },
             ],
           },
         };
@@ -188,8 +211,16 @@ export function updateNodesData(
             ...data,
             metrics: [
               { label: 'Written', value: plugin.written },
-              { label: 'Format failed', value: plugin.format_failed, isError: plugin.format_failed > 0 },
-              { label: 'Write failed', value: plugin.write_failed, isError: plugin.write_failed > 0 },
+              {
+                label: 'Format failed',
+                value: plugin.format_failed,
+                isError: plugin.format_failed > 0,
+              },
+              {
+                label: 'Write failed',
+                value: plugin.write_failed,
+                isError: plugin.write_failed > 0,
+              },
             ],
           },
         };
@@ -200,5 +231,8 @@ export function updateNodesData(
 
 export function computeGraphHeight(stats: GeneratorStats): number {
   const maxCount = Math.max(stats.input.length, 1, stats.output.length);
-  return Math.max(MIN_GRAPH_HEIGHT, (maxCount - 1) * NODE_SPACING_Y + MAX_NODE_HEIGHT + GRAPH_PADDING);
+  return Math.max(
+    MIN_GRAPH_HEIGHT,
+    (maxCount - 1) * NODE_SPACING_Y + MAX_NODE_HEIGHT + GRAPH_PADDING
+  );
 }

--- a/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/index.test.tsx
+++ b/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/index.test.tsx
@@ -1,0 +1,147 @@
+import { StateEffect } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { UseQueryResult } from '@tanstack/react-query';
+import { act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FileEditor } from '.';
+import {
+  useGeneratorFileContent,
+  useGeneratorFileTree,
+  usePutGeneratorFileMutation,
+} from '@/api/hooks/useGeneratorConfigs';
+import { FileNode } from '@/api/routes/generator-configs/schemas';
+import { ProjectNameProvider } from '@/pages/ProjectPage/context/ProjectNameContext';
+import { renderWithProviders } from '@/test/render';
+
+vi.mock('@/api/hooks/useGeneratorConfigs', () => ({
+  useGeneratorFileTree: vi.fn(),
+  useGeneratorFileContent: vi.fn(),
+  usePutGeneratorFileMutation: vi.fn(),
+}));
+
+const PROJECT = 'demo';
+const FILE_PATH = 'templates/event.json.jinja';
+const FILE_CONTENT = '{"event": "first"}\n';
+
+const FILE_TREE: FileNode[] = [
+  {
+    name: 'templates',
+    is_dir: true,
+    size_in_bytes: null,
+    children: [
+      {
+        name: 'event.json.jinja',
+        is_dir: false,
+        size_in_bytes: FILE_CONTENT.length,
+        children: null,
+      },
+    ],
+  },
+];
+
+function resolved<T>(data: T): UseQueryResult<T, Error> {
+  return {
+    data,
+    isPending: false,
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+    error: null,
+  } as unknown as UseQueryResult<T, Error>;
+}
+
+const save = vi.fn();
+
+beforeEach(() => {
+  vi.mocked(useGeneratorFileTree).mockReturnValue(resolved(FILE_TREE));
+  vi.mocked(useGeneratorFileContent).mockReturnValue(resolved(FILE_CONTENT));
+  vi.mocked(usePutGeneratorFileMutation).mockReturnValue({
+    mutate: save,
+  } as unknown as ReturnType<typeof usePutGeneratorFileMutation>);
+});
+
+function openEditor() {
+  const setSaved = vi.fn();
+
+  const { container } = renderWithProviders(
+    <ProjectNameProvider initialProjectName={PROJECT}>
+      <FileEditor filePath={FILE_PATH} setSaved={setSaved} />
+    </ProjectNameProvider>
+  );
+
+  const editor = container.querySelector<HTMLElement>('.cm-editor');
+  const view = editor === null ? null : EditorView.findFromDOM(editor);
+
+  if (view === null) {
+    throw new Error('the editor did not mount');
+  }
+
+  return { container, view, setSaved };
+}
+
+function typeText(view: EditorView, text: string) {
+  for (const character of text) {
+    act(() => {
+      view.dispatch({
+        changes: { from: view.state.doc.length, insert: character },
+      });
+    });
+  }
+}
+
+describe('FileEditor', () => {
+  it('keeps its configuration while the document is edited', () => {
+    // Rebuilding the configuration is the heaviest editor operation short of
+    // recreating the view, and whatever an extension keeps in a state field
+    // outlives it only while the extension instance stays the same.
+    const reconfigure = vi.spyOn(StateEffect.reconfigure, 'of');
+
+    const { view } = openEditor();
+    const onMount = reconfigure.mock.calls.length;
+
+    typeText(view, 'edited');
+
+    expect(view.state.doc.toString()).toBe(`${FILE_CONTENT}edited`);
+    expect(reconfigure).toHaveBeenCalledTimes(onMount);
+  });
+
+  it('reports the file as unsaved on the first edit', () => {
+    const { view, setSaved } = openEditor();
+    expect(setSaved).not.toHaveBeenCalled();
+
+    typeText(view, 'e');
+
+    expect(setSaved).toHaveBeenCalledWith(false);
+  });
+
+  it('opens the search panel on Mod-f', async () => {
+    const user = userEvent.setup();
+    const { container, view } = openEditor();
+    expect(container.querySelector('.ev-cm-search')).toBeNull();
+
+    view.contentDOM.focus();
+    await user.keyboard('{Control>}f{/Control}');
+
+    expect(container.querySelector('.ev-cm-search')).toBeInTheDocument();
+  });
+
+  it('saves the edited content on Mod-s', async () => {
+    const user = userEvent.setup();
+    const { view } = openEditor();
+
+    typeText(view, 'edited');
+    view.contentDOM.focus();
+    await user.keyboard('{Control>}s{/Control}');
+
+    expect(save).toHaveBeenCalledWith(
+      {
+        name: PROJECT,
+        filepath: FILE_PATH,
+        content: `${FILE_CONTENT}edited`,
+      },
+      expect.anything()
+    );
+  });
+});

--- a/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/index.tsx
+++ b/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/index.tsx
@@ -1,20 +1,14 @@
-import { autocompletion } from '@codemirror/autocomplete';
-import { jinja } from '@codemirror/lang-jinja';
-import { json } from '@codemirror/lang-json';
-import { markdown } from '@codemirror/lang-markdown';
-import { python } from '@codemirror/lang-python';
-import { yaml } from '@codemirror/lang-yaml';
 import { keymap } from '@codemirror/view';
 import { Alert, Box, Skeleton, useMantineColorScheme } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import CodeMirror from '@uiw/react-codemirror';
 import bytes from 'bytes';
-import { FC, useEffect, useMemo, useRef, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { SearchPanel } from './SearchPanel';
 import { SearchPanelHandle, searchPanel } from './SearchPanel/extension';
-import { jinjaCompletion } from './completions';
+import { languageExtensions } from './language';
 import {
   useGeneratorFileContent,
   useGeneratorFileTree,
@@ -72,19 +66,8 @@ export const FileEditor: FC<FileEditorProps> = ({
   const [content, setContent] = useState<string>('');
   const [isTouched, setTouched] = useState(false);
 
-  // The search panel is a CodeMirror panel with a React body: the extension
-  // hands over the element it mounted, the controls are rendered into it.
   const [searchHandle, setSearchHandle] = useState<SearchPanelHandle | null>(
     null
-  );
-  const searchExtension = useMemo(
-    () =>
-      searchPanel({
-        onOpen: setSearchHandle,
-        onClose: (closed) =>
-          setSearchHandle((current) => (current === closed ? null : current)),
-      }),
-    []
   );
 
   useEffect(() => {
@@ -132,37 +115,39 @@ export const FileEditor: FC<FileEditorProps> = ({
     registerSave?.(() => saveRef.current());
   }, [registerSave]);
 
-  const saveKeymap = keymap.of([
-    {
-      key: 'Mod-s',
-      preventDefault: true,
-      run: () => {
-        handleSave();
-        return true;
-      },
-    },
-  ]);
+  // The editor rebuilds its whole configuration whenever this array or the
+  // change handler changes identity, so both stay stable while the file is
+  // edited. The keymap goes through the save ref for the same reason: the
+  // save closes over the content and is rebuilt on every keystroke.
+  const extensions = useMemo(
+    () => [
+      ...languageExtensions(filePath),
+      keymap.of([
+        {
+          key: 'Mod-s',
+          preventDefault: true,
+          run: () => {
+            saveRef.current();
+            return true;
+          },
+        },
+      ]),
+      // The search panel is a CodeMirror panel with a React body: the
+      // extension hands over the element it mounted, the controls are
+      // rendered into it.
+      searchPanel({
+        onOpen: setSearchHandle,
+        onClose: (closed) =>
+          setSearchHandle((current) => (current === closed ? null : current)),
+      }),
+    ],
+    [filePath]
+  );
 
-  const extensions = [];
-
-  if (filePath.endsWith('.jinja')) {
-    extensions.push(
-      jinja(),
-      autocompletion({
-        override: [jinjaCompletion],
-      })
-    );
-  } else if (filePath.endsWith('.py')) {
-    extensions.push(python());
-  } else if (filePath.endsWith('.json')) {
-    extensions.push(json());
-  } else if (/\.ya?ml$/.test(filePath)) {
-    extensions.push(yaml());
-  } else if (filePath.endsWith('.md')) {
-    extensions.push(markdown());
-  }
-
-  extensions.push(saveKeymap, searchExtension);
+  const handleChange = useCallback((value: string) => {
+    setContent(value);
+    setTouched(true);
+  }, []);
 
   if (isTooLarge) {
     return (
@@ -203,13 +188,7 @@ export const FileEditor: FC<FileEditorProps> = ({
       <>
         <CodeMirror
           value={content}
-          onChange={(value) => {
-            setContent(value);
-
-            if (!isTouched) {
-              setTouched(true);
-            }
-          }}
+          onChange={handleChange}
           height={height}
           extensions={extensions}
           theme={cmTheme(colorScheme)}

--- a/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/language.test.ts
+++ b/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/language.test.ts
@@ -1,0 +1,37 @@
+import { language } from '@codemirror/language';
+import { EditorState } from '@codemirror/state';
+import { describe, expect, it } from 'vitest';
+
+import { languageExtensions } from './language';
+
+function languageOf(filePath: string): string | null {
+  const state = EditorState.create({
+    extensions: languageExtensions(filePath),
+  });
+
+  return state.facet(language)?.name ?? null;
+}
+
+describe('languageExtensions', () => {
+  it.each([
+    ['templates/event.json.jinja', 'jinja'],
+    ['scripts/produce.py', 'python'],
+    ['samples/hosts.json', 'json'],
+    ['generator.yml', 'yaml'],
+    ['generator.yaml', 'yaml'],
+    ['README.md', 'markdown'],
+  ])('opens %s in the %s mode', (filePath, expected) => {
+    expect(languageOf(filePath)).toBe(expected);
+  });
+
+  it('opens a file of an unknown type as plain text', () => {
+    expect(languageExtensions('samples/hosts.csv')).toEqual([]);
+    expect(languageOf('samples/hosts.csv')).toBeNull();
+  });
+
+  it('adds the completion source to templates only', () => {
+    // The mode and the completion source; every other mode ships alone.
+    expect(languageExtensions('templates/event.json.jinja')).toHaveLength(2);
+    expect(languageExtensions('samples/hosts.json')).toHaveLength(1);
+  });
+});

--- a/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/language.ts
+++ b/eventum/ui/src/pages/ProjectPage/common/EditorTab/FileEditor/language.ts
@@ -1,0 +1,38 @@
+import { autocompletion } from '@codemirror/autocomplete';
+import { jinja } from '@codemirror/lang-jinja';
+import { json } from '@codemirror/lang-json';
+import { markdown } from '@codemirror/lang-markdown';
+import { python } from '@codemirror/lang-python';
+import { yaml } from '@codemirror/lang-yaml';
+import { Extension } from '@codemirror/state';
+
+import { jinjaCompletion } from './completions';
+
+/**
+ * Editor extensions for the language of `filePath`: its syntax mode, and
+ * the completion source where the language has one. A file the editor has
+ * no mode for opens as plain text.
+ */
+export function languageExtensions(filePath: string): Extension[] {
+  if (filePath.endsWith('.jinja')) {
+    return [jinja(), autocompletion({ override: [jinjaCompletion] })];
+  }
+
+  if (filePath.endsWith('.py')) {
+    return [python()];
+  }
+
+  if (filePath.endsWith('.json')) {
+    return [json()];
+  }
+
+  if (/\.ya?ml$/.test(filePath)) {
+    return [yaml()];
+  }
+
+  if (filePath.endsWith('.md')) {
+    return [markdown()];
+  }
+
+  return [];
+}

--- a/eventum/ui/src/pages/ProjectPage/components/ProjectFileSelect.tsx
+++ b/eventum/ui/src/pages/ProjectPage/components/ProjectFileSelect.tsx
@@ -1,10 +1,4 @@
-import {
-  Alert,
-  Select,
-  SelectProps,
-  Skeleton,
-  Stack,
-} from '@mantine/core';
+import { Alert, Select, SelectProps, Skeleton, Stack } from '@mantine/core';
 import { FC, useMemo } from 'react';
 
 import { useGeneratorFileTree } from '@/api/hooks/useGeneratorConfigs';

--- a/eventum/ui/src/pages/ScenarioPage/AddGeneratorModal.tsx
+++ b/eventum/ui/src/pages/ScenarioPage/AddGeneratorModal.tsx
@@ -108,7 +108,7 @@ export const AddGeneratorModal: FC<AddGeneratorModalProps> = ({
         onError: (addError) => {
           showErrorNotification('Failed to add instance', addError);
         },
-      },
+      }
     );
   }
 

--- a/eventum/ui/src/pages/ScenarioPage/GlobalStatePanel.tsx
+++ b/eventum/ui/src/pages/ScenarioPage/GlobalStatePanel.tsx
@@ -18,7 +18,9 @@ interface GlobalStatePanelProps {
   scenarioName: string;
 }
 
-export const GlobalStatePanel: FC<GlobalStatePanelProps> = ({ scenarioName }) => {
+export const GlobalStatePanel: FC<GlobalStatePanelProps> = ({
+  scenarioName,
+}) => {
   const { data, isLoading, isError, error, isSuccess, refetch } =
     useScenarioGlobalState(scenarioName, { refetchInterval: 5000 });
   const updateState = useUpdateScenarioGlobalStateMutation(scenarioName);
@@ -36,10 +38,10 @@ export const GlobalStatePanel: FC<GlobalStatePanelProps> = ({ scenarioName }) =>
           onError: (updateError) => {
             showErrorNotification('Failed to update key', updateError);
           },
-        },
+        }
       );
     },
-    [updateState],
+    [updateState]
   );
 
   const handleDeleteKey = useCallback(
@@ -53,7 +55,7 @@ export const GlobalStatePanel: FC<GlobalStatePanelProps> = ({ scenarioName }) =>
         },
       });
     },
-    [deleteKey],
+    [deleteKey]
   );
 
   const handleAddKey = useCallback(
@@ -67,10 +69,10 @@ export const GlobalStatePanel: FC<GlobalStatePanelProps> = ({ scenarioName }) =>
           onError: (addError) => {
             showErrorNotification('Failed to add key', addError);
           },
-        },
+        }
       );
     },
-    [updateState],
+    [updateState]
   );
 
   const handleClear = useCallback(() => {

--- a/eventum/ui/src/pages/ScenarioPage/globals-usage.ts
+++ b/eventum/ui/src/pages/ScenarioPage/globals-usage.ts
@@ -6,7 +6,7 @@ export function collectGlobalKeys(
   globalsUsageMap: Map<
     string,
     { writes: { key: string }[]; reads: { key: string }[] } | undefined
-  >,
+  >
 ): string[] {
   const keys = new Set<string>();
   for (const usage of globalsUsageMap.values()) {

--- a/eventum/ui/src/pages/ScenariosPage/CreateScenarioModal.tsx
+++ b/eventum/ui/src/pages/ScenariosPage/CreateScenarioModal.tsx
@@ -29,15 +29,13 @@ export const CreateScenarioModal = () => {
 
   const existingScenarios = useMemo(
     () =>
-      new Set(
-        (startupEntries ?? []).flatMap((entry) => entry.scenarios ?? []),
-      ),
-    [startupEntries],
+      new Set((startupEntries ?? []).flatMap((entry) => entry.scenarios ?? [])),
+    [startupEntries]
   );
 
   const availableInstances = useMemo(
     () => (startupEntries ?? []).map((entry) => entry.id),
-    [startupEntries],
+    [startupEntries]
   );
 
   const form = useForm<FormValues>({
@@ -71,7 +69,7 @@ export const CreateScenarioModal = () => {
       }
       showSuccessNotification(
         'Created',
-        `Scenario "${name}" created with ${values.instances.length} instance(s)`,
+        `Scenario "${name}" created with ${values.instances.length} instance(s)`
       );
       modals.closeAll();
     } catch (error) {
@@ -109,11 +107,7 @@ export const CreateScenarioModal = () => {
         )}
 
         <Group justify="flex-end">
-          <Button
-            disabled={!form.isValid()}
-            loading={isCreating}
-            type="submit"
-          >
+          <Button disabled={!form.isValid()} loading={isCreating} type="submit">
             Create
           </Button>
         </Group>

--- a/eventum/ui/src/test/render.tsx
+++ b/eventum/ui/src/test/render.tsx
@@ -1,0 +1,37 @@
+import { MantineProvider } from '@mantine/core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RenderOptions, RenderResult, render } from '@testing-library/react';
+import { FC, ReactElement, ReactNode } from 'react';
+
+import { cssVariablesResolver, theme } from '@/theme';
+
+/**
+ * Render a component under the providers the app mounts it in: the studio
+ * theme and a query client of its own, so no cached response leaks from one
+ * test into the next.
+ */
+export function renderWithProviders(
+  ui: ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>
+): RenderResult {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const Providers: FC<{ children: ReactNode }> = ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <MantineProvider
+        theme={theme}
+        cssVariablesResolver={cssVariablesResolver}
+        defaultColorScheme="dark"
+      >
+        {children}
+      </MantineProvider>
+    </QueryClientProvider>
+  );
+
+  return render(ui, { wrapper: Providers, ...options });
+}

--- a/eventum/ui/src/test/setup.ts
+++ b/eventum/ui/src/test/setup.ts
@@ -1,0 +1,50 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+// Vitest runs without globals, so the automatic unmount React Testing
+// Library installs on `afterEach` is not wired up - do it here.
+afterEach(cleanup);
+
+const noop = () => {
+  // The stubs below record nothing and report nothing.
+};
+
+// jsdom lays nothing out and implements none of the observers the app
+// mounts with: Mantine reads `matchMedia`, and the editor observes both the
+// size and the visibility of its element. The stubs are inert - anything
+// that depends on real geometry belongs in a browser test.
+Object.defineProperty(globalThis, 'matchMedia', {
+  writable: true,
+  value: (query: string): MediaQueryList =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: noop,
+      removeListener: noop,
+      addEventListener: noop,
+      removeEventListener: noop,
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList,
+});
+
+class ResizeObserverStub implements ResizeObserver {
+  observe = noop;
+  unobserve = noop;
+  disconnect = noop;
+}
+
+class IntersectionObserverStub implements IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = '';
+  readonly thresholds: readonly number[] = [];
+
+  observe = noop;
+  unobserve = noop;
+  disconnect = noop;
+  takeRecords = (): IntersectionObserverEntry[] => [];
+}
+
+globalThis.ResizeObserver = ResizeObserverStub;
+globalThis.IntersectionObserver = IntersectionObserverStub;

--- a/eventum/ui/vitest.config.ts
+++ b/eventum/ui/vitest.config.ts
@@ -7,8 +7,10 @@ export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
-      include: ['src/**/*.test.ts'],
-      environment: 'node',
+      include: ['src/**/*.test.{ts,tsx}'],
+      environment: 'jsdom',
+      setupFiles: ['./src/test/setup.ts'],
+      restoreMocks: true,
     },
   })
 );


### PR DESCRIPTION
Closes #208.

## Problem

`FileEditor` built its `extensions` array inline in the render body and passed an inline `onChange`. `useCodeMirror` reconfigures the whole editor whenever either changes identity, so every keystroke dispatched a full `StateEffect.reconfigure` on top of the document transaction — the language mode, autocomplete source, save keymap and search extension were all rebuilt per character.

The array could not be memoized as it stood: the save keymap closed over `handleSave`, which closes over `content`.

## Fix

- The save keymap reaches the save through the ref the Save button already goes through, leaving the file path as the only thing the extensions depend on.
- One `useMemo` on `[filePath]` builds the whole extension list; the search extension moves into it, so the standalone memo added with the search panel in #196 is gone.
- `onChange` is a stable `useCallback` — setting the touched flag on an already-touched file is a no-op, so the handler no longer reads it.
- The language mode moves to `language.ts` behind `languageExtensions`.

Behaviour is unchanged: the editor still reports edits, still saves on Ctrl/Cmd-S, and Jinja autocomplete is wired exactly as before.

## Test harness

The suite ran in a node environment over `src/**/*.test.ts`, so only pure helpers could be covered. It now runs in jsdom over `.ts` and `.tsx`, with jest-dom matchers, an unmount after each test, and stubs for the browser APIs jsdom leaves out (`matchMedia`, `ResizeObserver`, `IntersectionObserver`). `renderWithProviders` wraps a component in the app theme and a query client of its own. The convention is recorded in `.claude/rules/frontend/ui.md`.

## Tests

`FileEditor` gets four component tests — configuration stability, the unsaved flag, save on Mod-s with the current content, and the search panel opening on Mod-f — plus eight over the language mapping.

The stability test counts `StateEffect.reconfigure.of` calls. Against the pre-fix component it reports **6 reconfigurations for 6 typed characters**; after the fix, none.

## Formatting

Nineteen files had drifted from `.prettierrc`, since nothing enforced it — `pnpm lint` runs eslint, and `eslint-config-prettier` only switches off the rules that clash with prettier. They are reformatted in their own commit (whitespace only; the one import statement that moves is type-only), and `format` / `format:check` scripts now cover the same files.

## Checks

| | |
|---|---|
| `pnpm lint` / `pnpm format:check` | clean |
| `pnpm test` | 53 passed |
| `pnpm build` | ok |
| `ruff check` / `ruff format` / `mypy` | clean |
| `pytest --ignore=tests/integration` | 1506 passed |