### PR TITLE
fix(ui): key the plugin parameters form on the plugin, not its slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### 🐛 Bug Fixes
+
+- **Bound the plugin parameters form to the plugin instead of its position in the list** — deleting an input or output plugin left the form filled with the deleted plugin's values, and the next edit wrote them over the plugin that took its place. Deleting a plugin listed above the selected one also moved the selection to a neighbour
+
 ## 2.7.0 (2026-08-01)
 
 ### 🚀 New Features

--- a/eventum/ui/src/pages/ProjectPage/studio/StudioProvider.tsx
+++ b/eventum/ui/src/pages/ProjectPage/studio/StudioProvider.tsx
@@ -24,6 +24,7 @@ import {
   StudioShellContext,
   StudioShellValue,
 } from './context';
+import { nextSelectedIndex } from './selection';
 import { useUpdateGeneratorConfigMutation } from '@/api/hooks/useGeneratorConfigs';
 import { PLUGIN_DEFAULT_CONFIGS } from '@/api/routes/generator-configs/modules/plugins/registry';
 import {
@@ -47,6 +48,22 @@ interface StudioProviderProps {
 
 const pluginNames = (plugins: Record<string, unknown>[]): string[] =>
   plugins.map((plugin) => Object.keys(plugin)[0]!);
+
+// Plugins are addressed by position, but a position is not an identity: a
+// removal shifts every plugin after it into a slot that used to hold another
+// one. Each added plugin therefore gets an id that stays with it, so views
+// can key on the plugin itself instead of on the slot it occupies.
+let pluginInstanceCounter = 0;
+
+const nextPluginId = (): string => `plugin-${++pluginInstanceCounter}`;
+
+const pluginIds = (count: number): string[] =>
+  Array.from({ length: count }, () => nextPluginId());
+
+const withoutIndex = <T,>(items: T[], index: number): T[] => [
+  ...items.slice(0, index),
+  ...items.slice(index + 1),
+];
 
 // A structurally-valid but empty config, used only to satisfy the config
 // context type while in recovery mode. It is never persisted - saveConfig is
@@ -75,6 +92,12 @@ export const StudioProvider: FC<StudioProviderProps> = ({
   );
   const [outputConfig, setOutputConfig] = useState<OutputPluginsNamedConfig>(
     serverConfig?.output ?? []
+  );
+  const [inputIds, setInputIds] = useState<string[]>(() =>
+    pluginIds(serverConfig?.input.length ?? 0)
+  );
+  const [outputIds, setOutputIds] = useState<string[]>(() =>
+    pluginIds(serverConfig?.output.length ?? 0)
   );
   const [inputSelected, setInputSelected] = useState(0);
   const [outputSelected, setOutputSelected] = useState(0);
@@ -106,23 +129,24 @@ export const StudioProvider: FC<StudioProviderProps> = ({
     () => ({
       names: pluginNames(inputConfig),
       selected: inputSelected,
+      selectedId: inputIds[inputSelected],
       setSelected: setInputSelected,
-      add: (name) =>
+      add: (name) => {
         setInputConfig(
           (prev) =>
             [
               ...prev,
               { [name]: PLUGIN_DEFAULT_CONFIGS.input[name] },
             ] as InputPluginsNamedConfig
-        ),
+        );
+        setInputIds((prev) => [...prev, nextPluginId()]);
+      },
       remove: (index) => {
-        setInputConfig((prev) => {
-          const next = [...prev.slice(0, index), ...prev.slice(index + 1)];
-          setInputSelected((sel) =>
-            sel >= next.length ? Math.max(next.length - 1, 0) : sel
-          );
-          return next;
-        });
+        setInputConfig((prev) => withoutIndex(prev, index));
+        setInputIds((prev) => withoutIndex(prev, index));
+        setInputSelected((sel) =>
+          nextSelectedIndex(sel, index, inputConfig.length - 1)
+        );
       },
       change: (cfg) =>
         setInputConfig((prev) => {
@@ -133,7 +157,7 @@ export const StudioProvider: FC<StudioProviderProps> = ({
       getConfig: () => inputConfigRef.current,
       getSelected: () => inputSelectedRef.current,
     }),
-    [inputConfig, inputSelected]
+    [inputConfig, inputIds, inputSelected]
   );
 
   const event = useMemo<EventStage>(() => {
@@ -157,23 +181,24 @@ export const StudioProvider: FC<StudioProviderProps> = ({
     () => ({
       names: pluginNames(outputConfig),
       selected: outputSelected,
+      selectedId: outputIds[outputSelected],
       setSelected: setOutputSelected,
-      add: (name) =>
+      add: (name) => {
         setOutputConfig(
           (prev) =>
             [
               ...prev,
               { [name]: PLUGIN_DEFAULT_CONFIGS.output[name] },
             ] as OutputPluginsNamedConfig
-        ),
+        );
+        setOutputIds((prev) => [...prev, nextPluginId()]);
+      },
       remove: (index) => {
-        setOutputConfig((prev) => {
-          const next = [...prev.slice(0, index), ...prev.slice(index + 1)];
-          setOutputSelected((sel) =>
-            sel >= next.length ? Math.max(next.length - 1, 0) : sel
-          );
-          return next;
-        });
+        setOutputConfig((prev) => withoutIndex(prev, index));
+        setOutputIds((prev) => withoutIndex(prev, index));
+        setOutputSelected((sel) =>
+          nextSelectedIndex(sel, index, outputConfig.length - 1)
+        );
       },
       change: (cfg) =>
         setOutputConfig((prev) => {
@@ -182,7 +207,7 @@ export const StudioProvider: FC<StudioProviderProps> = ({
           return next;
         }),
     }),
-    [outputConfig, outputSelected]
+    [outputConfig, outputIds, outputSelected]
   );
 
   const updateConfig = useUpdateGeneratorConfigMutation();

--- a/eventum/ui/src/pages/ProjectPage/studio/context.ts
+++ b/eventum/ui/src/pages/ProjectPage/studio/context.ts
@@ -20,6 +20,9 @@ export type SaverFn = () => void;
 export interface InputStage {
   names: string[];
   selected: number;
+  // Identity of the plugin at the selected position - unlike the position
+  // itself, it changes whenever another plugin takes that slot.
+  selectedId: string | undefined;
   setSelected: (index: number) => void;
   add: (name: InputPluginName) => void;
   remove: (index: number) => void;
@@ -40,6 +43,7 @@ export interface EventStage {
 export interface OutputStage {
   names: string[];
   selected: number;
+  selectedId: string | undefined;
   setSelected: (index: number) => void;
   add: (name: OutputPluginName) => void;
   remove: (index: number) => void;

--- a/eventum/ui/src/pages/ProjectPage/studio/panels/InspectorPanel.test.tsx
+++ b/eventum/ui/src/pages/ProjectPage/studio/panels/InspectorPanel.test.tsx
@@ -1,0 +1,121 @@
+import { ModalsProvider } from '@mantine/modals';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FC, useEffect } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { InspectorPanel } from './InspectorPanel';
+import { PLUGIN_DEFAULT_CONFIGS } from '@/api/routes/generator-configs/modules/plugins/registry';
+import { GeneratorConfig } from '@/api/routes/generator-configs/schemas';
+import { FileTreeProvider } from '@/pages/ProjectPage/context/FileTreeContext';
+import { ProjectNameProvider } from '@/pages/ProjectPage/context/ProjectNameContext';
+import { StudioProvider } from '@/pages/ProjectPage/studio/StudioProvider';
+import { Stage, useStudioShell } from '@/pages/ProjectPage/studio/context';
+import { renderWithProviders } from '@/test/render';
+
+const CONFIG: GeneratorConfig = {
+  input: [
+    { cron: { expression: '1 * * * *', count: 1 } },
+    { cron: { expression: '2 * * * *', count: 2 } },
+    { cron: { expression: '3 * * * *', count: 3 } },
+  ],
+  event: { template: PLUGIN_DEFAULT_CONFIGS.event.template },
+  output: [
+    { file: { path: './output/first.log' } },
+    { file: { path: './output/second.log' } },
+  ],
+};
+
+const OpenStage: FC<{ stage: Stage }> = ({ stage }) => {
+  const { setActiveStage } = useStudioShell();
+  useEffect(() => setActiveStage(stage), [setActiveStage, stage]);
+  return null;
+};
+
+function renderInspector(stage: Stage): void {
+  renderWithProviders(
+    <ProjectNameProvider initialProjectName="demo">
+      <FileTreeProvider>
+        <StudioProvider serverConfig={CONFIG}>
+          <ModalsProvider>
+            <OpenStage stage={stage} />
+            <InspectorPanel />
+          </ModalsProvider>
+        </StudioProvider>
+      </FileTreeProvider>
+    </ProjectNameProvider>
+  );
+}
+
+// jsdom cannot resolve the CSS variables Mantine sizes its controls with, so
+// `getComputedStyle` - and every role query built on it - throws. Controls
+// are addressed by placeholder, title and text instead.
+async function deletePlugin(index: number): Promise<void> {
+  const user = userEvent.setup();
+  await user.click(screen.getAllByTitle('Remove')[index]!);
+  await user.click(await screen.findByText('Delete'));
+  await waitFor(() => expect(screen.queryByText('Delete')).toBeNull());
+}
+
+function activePluginLabel(): string | null {
+  return document.querySelector('a[data-active]')?.textContent ?? null;
+}
+
+describe('InspectorPanel plugin deletion', () => {
+  it('reloads the parameters form with the plugin that takes the slot', async () => {
+    renderInspector('input');
+
+    expect(screen.getByPlaceholderText('cron expression')).toHaveValue(
+      '1 * * * *'
+    );
+
+    await deletePlugin(0);
+
+    expect(activePluginLabel()).toContain('cron #1');
+    expect(screen.getByPlaceholderText('cron expression')).toHaveValue(
+      '2 * * * *'
+    );
+  });
+
+  it('keeps the selected plugin when an earlier one is deleted', async () => {
+    const user = userEvent.setup();
+    renderInspector('input');
+
+    await user.click(screen.getByText('cron #2'));
+    expect(screen.getByPlaceholderText('cron expression')).toHaveValue(
+      '2 * * * *'
+    );
+
+    await deletePlugin(0);
+
+    expect(activePluginLabel()).toContain('cron #1');
+    expect(screen.getByPlaceholderText('cron expression')).toHaveValue(
+      '2 * * * *'
+    );
+  });
+
+  it('reloads the parameters form of output plugins as well', async () => {
+    renderInspector('output');
+
+    expect(screen.getByPlaceholderText('file path')).toHaveValue(
+      './output/first.log'
+    );
+
+    await deletePlugin(0);
+
+    expect(activePluginLabel()).toContain('file #1');
+    expect(screen.getByPlaceholderText('file path')).toHaveValue(
+      './output/second.log'
+    );
+  });
+
+  it('drops the parameters form when the last plugin is deleted', async () => {
+    renderInspector('output');
+
+    await deletePlugin(0);
+    await deletePlugin(0);
+
+    expect(screen.queryByPlaceholderText('file path')).toBeNull();
+    expect(screen.getByText('No plugin added yet')).toBeInTheDocument();
+  });
+});

--- a/eventum/ui/src/pages/ProjectPage/studio/panels/InspectorPanel.tsx
+++ b/eventum/ui/src/pages/ProjectPage/studio/panels/InspectorPanel.tsx
@@ -64,7 +64,7 @@ const StageBody: FC = () => {
         <Section title="Parameters">
           {cfg ? (
             <InputPluginParams
-              key={input.selected}
+              key={input.selectedId}
               inputPluginConfig={cfg}
               onChange={input.change}
             />
@@ -130,7 +130,7 @@ const StageBody: FC = () => {
       <Section title="Parameters">
         {cfg ? (
           <OutputPluginParams
-            key={output.selected}
+            key={output.selectedId}
             outputPluginConfig={cfg}
             onChange={output.change}
           />

--- a/eventum/ui/src/pages/ProjectPage/studio/selection.test.ts
+++ b/eventum/ui/src/pages/ProjectPage/studio/selection.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { nextSelectedIndex } from './selection';
+
+describe('nextSelectedIndex', () => {
+  it('follows the selected plugin when an earlier one is removed', () => {
+    // [A, B, C] with B selected, A removed -> [B, C] with B selected.
+    expect(nextSelectedIndex(1, 0, 2)).toBe(0);
+    expect(nextSelectedIndex(3, 1, 3)).toBe(2);
+  });
+
+  it('keeps the position when the selected plugin is removed', () => {
+    // [A, B, C] with B selected, B removed -> [A, C] with C selected.
+    expect(nextSelectedIndex(1, 1, 2)).toBe(1);
+  });
+
+  it('clamps to the last plugin when the selected one was last', () => {
+    // [A, B] with B selected, B removed -> [A] with A selected.
+    expect(nextSelectedIndex(1, 1, 1)).toBe(0);
+  });
+
+  it('keeps the selection when a later plugin is removed', () => {
+    // [A, B, C] with A selected, C removed -> [A, B] with A selected.
+    expect(nextSelectedIndex(0, 2, 2)).toBe(0);
+  });
+
+  it('falls back to zero when the list is emptied', () => {
+    expect(nextSelectedIndex(0, 0, 0)).toBe(0);
+  });
+});

--- a/eventum/ui/src/pages/ProjectPage/studio/selection.ts
+++ b/eventum/ui/src/pages/ProjectPage/studio/selection.ts
@@ -1,0 +1,20 @@
+/**
+ * Position the selection takes after the plugin at `removed` is dropped
+ * from a list that is `length` items long afterwards.
+ *
+ * Removing a plugin that sits before the selected one keeps the same
+ * plugin selected by following it one position up. Removing the selected
+ * plugin itself keeps the position, which now holds its neighbour, and
+ * clamps it into the shortened list.
+ */
+export function nextSelectedIndex(
+  selected: number,
+  removed: number,
+  length: number
+): number {
+  if (removed < selected) {
+    return selected - 1;
+  }
+
+  return Math.min(selected, Math.max(length - 1, 0));
+}


### PR DESCRIPTION
Fixes #234. Deleting the selected input or output plugin in Studio left the Parameters form showing the deleted plugin's values instead of reloading for the plugin that took its place.

The form is worse than cosmetic: it writes back on every change, so the first keystroke after a deletion overwrote the surviving plugin's configuration with the deleted one's values.

## Cause

Two defects in the same operation.

The parameters form is initialized once from the config it mounts with, and the inspector remounted it by selection index (`key={input.selected}`). A removal that leaves the index unchanged - the selected plugin deleted anywhere but at the end of the list - hands the same form instance a different plugin, and React keeps the old one mounted.

The selection was only clamped to the list bounds, never remapped. Deleting a plugin listed above the selected one therefore moved the selection to a neighbour without the user asking for it.

## Changes

- Every added plugin carries an id that stays with it. The inspector keys the form on the id of the selected plugin, so the form reloads whenever another plugin takes that slot.
- The selection follows its plugin when an earlier one is removed, and keeps its position - clamped into the shortened list - otherwise. The rule lives in `studio/selection.ts`.
- Selection updates moved out of the config state updater, which must stay pure.

The event stage needs neither: it holds a single plugin and its form unmounts when that plugin is deleted.

## Verification

`pnpm test` 88 passed - 5 unit tests over the selection rule and 4 component tests driving the inspector through the delete dialog for both stages. Reverting the three source files with the tests in place fails 3 of the 4, reproducing exactly what the issue reports.

`pnpm lint`, `pnpm format:check` and `pnpm build` clean. The backend is untouched and still green: `ruff check`, `ruff format --check`, `mypy` over 452 files, `pytest` 1547 passed.