### PR TITLE
fix(core): report what pipeline backpressure actually observed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### 🐛 Bug Fixes
 
 - **Bound the plugin parameters form to the plugin instead of its position in the list** — deleting an input or output plugin left the form filled with the deleted plugin's values, and the next edit wrote them over the plugin that took its place. Deleting a plugin listed above the selected one also moved the selection to a neighbour
+- **Rewrote the pipeline backpressure warnings** — a write that ran out of time blamed the event rate and warned about losing events that were already lost. The three warnings now state what actually happened — a write was cancelled and its events counted as failed, or a queue filled up and events fall behind their timestamps — and carry the remedies as a separate hint, since a slow or unavailable output target, an oversized batch and a short write timeout produce the same symptom as an excessive rate. Repeated write timeouts are reported once per ten seconds per output plugin with a running count, instead of one line per cancelled write
 
 ## 2.7.0 (2026-08-01)
 

--- a/eventum/core/stages/event_stage.py
+++ b/eventum/core/stages/event_stage.py
@@ -154,9 +154,14 @@ class EventStage:
                         throttler(
                             logger.warning,
                             (
-                                'Events queue is full, consider decreasing '
-                                'EPS or changing batching settings to avoid '
-                                'time lag with actual event timestamps'
+                                'Events queue is full, events are '
+                                'produced later than their timestamps'
+                            ),
+                            hint=(
+                                'Output stage is not keeping up with the '
+                                'generation rate, consider checking the '
+                                'output target performance or decreasing '
+                                'the rate'
                             ),
                         )
 

--- a/eventum/core/stages/input_stage.py
+++ b/eventum/core/stages/input_stage.py
@@ -283,10 +283,13 @@ class InputStage:
                 throttler(
                     logger.warning,
                     (
-                        'Timestamps queue is full, consider '
-                        'decreasing EPS or changing batching '
-                        'settings to avoid time lag with actual '
-                        'event timestamps'
+                        'Timestamps queue is full, events are '
+                        'produced later than their timestamps'
+                    ),
+                    hint=(
+                        'Event and output stages are not keeping up '
+                        'with the generation rate, consider decreasing '
+                        'the rate or increasing the queue size'
                     ),
                 )
 

--- a/eventum/core/stages/output_stage.py
+++ b/eventum/core/stages/output_stage.py
@@ -1,11 +1,13 @@
 """Output stage of the pipeline — consumes events, writes to outputs."""
 
 import asyncio
+from collections import Counter, defaultdict
 from typing import TYPE_CHECKING, cast
 
 import structlog
 
 from eventum.plugins.output.exceptions import PluginOpenError, PluginWriteError
+from eventum.utils.throttler import Throttler
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -52,6 +54,13 @@ class OutputStage:
         self._semaphore = asyncio.Semaphore(
             value=self._params.max_concurrency,
         )
+
+        # timeouts are reported per task name (i.e. per output plugin)
+        # to keep one saturated target from muting the others
+        self._timeout_throttlers: defaultdict[str, Throttler] = defaultdict(
+            lambda: Throttler(limit=1, period=10),
+        )
+        self._timed_out_writes: Counter[str] = Counter()
 
     async def open(self) -> None:
         """Open all output plugins for writing.
@@ -143,6 +152,33 @@ class OutputStage:
             )
             self._tasks.clear()
 
+    def _report_write_timeouts(self, task_name: str) -> None:
+        """Report write operations of the task that timed out.
+
+        Parameters
+        ----------
+        task_name : str
+            Name of the task that timed out.
+
+        Notes
+        -----
+        Reported count is cumulative for the whole run, since the
+        reporting is throttled and single timeouts are not reported
+        each on their own.
+
+        """
+        logger.warning(
+            'Write operations timed out, their events are counted as failed',
+            task_name=task_name,
+            timeout=self._params.write_timeout,
+            count=self._timed_out_writes[task_name],
+            hint=(
+                'Check load and availability of the output target, then '
+                'adjust write timeout, batch size, output concurrency '
+                'or generation rate'
+            ),
+        )
+
     def _handle_write_result(self, task: asyncio.Task[int]) -> None:
         """Handle result of an output plugin write task.
 
@@ -157,15 +193,11 @@ class OutputStage:
         except PluginWriteError as e:
             logger.error(str(e), **e.context)
         except TimeoutError:
-            logger.warning(
-                (
-                    'Write operation timed out, EPS is to high '
-                    'for output target, consider decreasing EPS '
-                    'or changing batching settings to avoid '
-                    'loosing events'
-                ),
-                task_name=task.get_name(),
-                timeout=self._params.write_timeout,
+            task_name = task.get_name()
+            self._timed_out_writes[task_name] += 1
+            self._timeout_throttlers[task_name](
+                self._report_write_timeouts,
+                task_name,
             )
         except Exception as e:
             logger.exception(

--- a/eventum/core/tests/test_event_stage.py
+++ b/eventum/core/tests/test_event_stage.py
@@ -2,11 +2,14 @@
 
 import queue as queue_mod
 import threading
+import time
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+import structlog.testing
 
 from eventum.core.parameters import GeneratorParameters
 from eventum.core.queue import PipelineQueue
@@ -523,3 +526,114 @@ def test_execute_fatal_error_shuts_down_input():
     # Input queue should be shut down so put raises ShutDown
     with pytest.raises(queue_mod.ShutDown):
         input_q.put(_make_timestamps(count=1))
+
+
+# - Backpressure ------------------------------------------------------
+
+
+def _make_blocked_stage(
+    output_q: PipelineQueue[list[str]],
+    *,
+    live_mode: bool,
+) -> tuple[threading.Thread, PipelineQueue, threading.Event]:
+    """Run a stage against an output queue that is already full.
+
+    The queue is never drained, so the stage stays blocked on put right
+    after it has checked the queue for fullness. Both queues have to be
+    shut down by the caller to release the stage.
+
+    Returns
+    -------
+    tuple[threading.Thread, PipelineQueue, threading.Event]
+        Stage thread, its input queue and an event set once the plugin
+        has produced the batch the stage blocks on.
+
+    """
+    produced = threading.Event()
+
+    def produce(params) -> list[str]:
+        produced.set()
+        return ['ev']
+
+    plugin = MagicMock()
+    plugin.produce.side_effect = produce
+
+    stage = _make_event_stage(
+        plugin=plugin,
+        params=_make_params(live_mode=live_mode),
+    )
+
+    input_q: PipelineQueue[IdentifiedTimestamps] = PipelineQueue(maxsize=10)
+    input_q.put(_make_timestamps(count=1))
+    output_q.put(['occupied'])
+
+    thread = threading.Thread(
+        target=stage.execute,
+        kwargs={'input': input_q, 'output': output_q},
+    )
+    thread.start()
+
+    return thread, input_q, produced
+
+
+def _release_stage(
+    thread: threading.Thread,
+    input_q: PipelineQueue,
+    output_q: PipelineQueue,
+) -> None:
+    """Unblock the stage waiting on a full queue and join its thread."""
+    output_q.shutdown()
+    input_q.shutdown()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+
+
+def _wait_for_warnings(
+    logs: Sequence[Mapping],
+    timeout: float = 5.0,
+) -> list[Mapping]:
+    """Wait until at least one warning is captured and return warnings."""
+    deadline = time.monotonic() + timeout
+
+    while time.monotonic() < deadline:
+        warnings = [e for e in logs if e['log_level'] == 'warning']
+        if warnings:
+            return warnings
+        time.sleep(0.01)
+
+    return []
+
+
+def test_full_output_queue_warns_in_live_mode():
+    """A full events queue is reported as a lag with an actionable hint."""
+    output_q: PipelineQueue[list[str]] = PipelineQueue(maxsize=1)
+
+    with structlog.testing.capture_logs() as logs:
+        thread, input_q, _ = _make_blocked_stage(output_q, live_mode=True)
+        warnings = _wait_for_warnings(logs)
+        _release_stage(thread, input_q, output_q)
+
+    assert len(warnings) == 1
+    assert warnings[0]['hint']
+
+    # the stage cannot know the rate is the cause, so it must not claim it
+    assert 'EPS' not in warnings[0]['event']
+
+
+def test_full_output_queue_stays_silent_in_sample_mode():
+    """Sample mode has no schedule to lag behind, so a full queue is ok."""
+    output_q: PipelineQueue[list[str]] = PipelineQueue(maxsize=1)
+
+    with structlog.testing.capture_logs() as logs:
+        thread, input_q, produced = _make_blocked_stage(
+            output_q,
+            live_mode=False,
+        )
+        assert produced.wait(timeout=5)
+
+        # the check follows the production immediately, so by the time
+        # the stage blocks on put it has already decided to stay silent
+        time.sleep(0.1)
+        _release_stage(thread, input_q, output_q)
+
+    assert not [entry for entry in logs if entry['log_level'] == 'warning']

--- a/eventum/core/tests/test_input_stage.py
+++ b/eventum/core/tests/test_input_stage.py
@@ -1,10 +1,13 @@
 """Tests for InputStage."""
 
 import threading
+import time
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
+import structlog.testing
 
 from eventum.core.parameters import GeneratorParameters
 from eventum.core.queue import PipelineQueue
@@ -320,3 +323,89 @@ def test_stop_interactive_plugins():
     p1.stop_interacting.assert_not_called()
     p2.stop_interacting.assert_called_once()
     p3.stop_interacting.assert_called_once()
+
+
+# - Backpressure ------------------------------------------------------
+
+
+def _run_stage_against_full_queue(
+    output_q: PipelineQueue,
+    *,
+    live_mode: bool,
+) -> threading.Thread:
+    """Run a stage against an output queue that is already full.
+
+    The queue is never drained, so the stage stays blocked on put right
+    after it has checked the queue for fullness. The queue has to be
+    shut down by the caller to release the stage.
+    """
+    source = _make_mock_source([_make_timestamps(count=1)])
+
+    stage = InputStage(
+        plugins=[_make_mock_input_plugin()],
+        params=_make_params(live_mode=live_mode),
+    )
+    stage._configured_non_interactive = source
+    stage._configured_interactive = None
+    stage._stop_event = threading.Event()
+
+    output_q.put(_make_timestamps(count=1))
+
+    thread = threading.Thread(
+        target=stage.execute,
+        kwargs={'output': output_q, 'skip_past': False},
+    )
+    thread.start()
+
+    return thread
+
+
+def _wait_for_warnings(
+    logs: Sequence[Mapping],
+    timeout: float = 5.0,
+) -> list[Mapping]:
+    """Wait until at least one warning is captured and return warnings."""
+    deadline = time.monotonic() + timeout
+
+    while time.monotonic() < deadline:
+        warnings = [e for e in logs if e['log_level'] == 'warning']
+        if warnings:
+            return warnings
+        time.sleep(0.01)
+
+    return []
+
+
+def test_full_output_queue_warns_in_live_mode():
+    """A full timestamps queue is reported as a lag with a hint."""
+    output_q: PipelineQueue[IdentifiedTimestamps] = PipelineQueue(maxsize=1)
+
+    with structlog.testing.capture_logs() as logs:
+        thread = _run_stage_against_full_queue(output_q, live_mode=True)
+        warnings = _wait_for_warnings(logs)
+        output_q.shutdown()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert len(warnings) == 1
+    assert warnings[0]['hint']
+
+    # the stage cannot know the rate is the cause, so it must not claim it
+    assert 'EPS' not in warnings[0]['event']
+
+
+def test_full_output_queue_stays_silent_in_sample_mode():
+    """Sample mode has no schedule to lag behind, so a full queue is ok."""
+    output_q: PipelineQueue[IdentifiedTimestamps] = PipelineQueue(maxsize=1)
+
+    with structlog.testing.capture_logs() as logs:
+        thread = _run_stage_against_full_queue(output_q, live_mode=False)
+
+        # the check precedes the put, so by the time the stage blocks
+        # on it the stage has already decided to stay silent
+        time.sleep(0.1)
+        output_q.shutdown()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert not [entry for entry in logs if entry['log_level'] == 'warning']

--- a/eventum/core/tests/test_output_stage.py
+++ b/eventum/core/tests/test_output_stage.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import structlog.testing
 
 from eventum.core.executor import ExecutionError
 from eventum.core.parameters import GeneratorParameters
@@ -50,6 +51,12 @@ def _feed_and_close(input_q: PipelineQueue, batches: list) -> None:
     for batch in batches:
         input_q.put(batch)
     input_q.close()
+
+
+async def _slow_write(events) -> int:
+    """Write that never completes within the tested write timeout."""
+    await asyncio.sleep(10)
+    return len(events)
 
 
 # - open() ------------------------------------------------------------
@@ -235,12 +242,7 @@ async def test_handle_write_result_plugin_write_error():
 async def test_handle_write_result_timeout():
     """Write timeout is handled (logged, not re-raised)."""
     p1 = _make_mock_output_plugin()
-
-    async def slow_write(events):
-        await asyncio.sleep(10)
-        return 1
-
-    p1.write.side_effect = slow_write
+    p1.write.side_effect = _slow_write
 
     params = _make_params(write_timeout=1)
     stage = _make_output_stage(plugins=[p1], params=params)
@@ -253,6 +255,92 @@ async def test_handle_write_result_timeout():
 
     await stage.execute(input=input_q)
     # Should complete without raising (timeout handled in callback)
+
+
+@pytest.mark.asyncio
+async def test_write_timeout_warning_states_fact_and_hint():
+    """Write timeout warning reports the observed fact with a hint."""
+    p1 = _make_mock_output_plugin()
+    p1.write.side_effect = _slow_write
+
+    params = _make_params(write_timeout=1)
+    stage = _make_output_stage(plugins=[p1], params=params)
+    input_q: PipelineQueue[list[str]] = PipelineQueue(maxsize=10)
+
+    threading.Thread(
+        target=_feed_and_close,
+        args=(input_q, [['ev1']]),
+    ).start()
+
+    with structlog.testing.capture_logs() as logs:
+        await stage.execute(input=input_q)
+
+    warnings = [entry for entry in logs if entry['log_level'] == 'warning']
+    assert len(warnings) == 1
+
+    entry = warnings[0]
+    assert entry['task_name'] == 'Writing with <mock output>'
+    assert entry['timeout'] == 1
+    assert entry['count'] == 1
+    assert entry['hint']
+
+    # the stage cannot know the rate is the cause, so it must not claim it
+    assert 'EPS' not in entry['event']
+
+
+@pytest.mark.asyncio
+async def test_write_timeouts_of_one_plugin_are_throttled():
+    """Repeated timeouts of one plugin are reported once per period."""
+    p1 = _make_mock_output_plugin()
+    p1.write.side_effect = _slow_write
+
+    params = _make_params(write_timeout=1)
+    stage = _make_output_stage(plugins=[p1], params=params)
+    input_q: PipelineQueue[list[str]] = PipelineQueue(maxsize=10)
+
+    threading.Thread(
+        target=_feed_and_close,
+        args=(input_q, [['ev1'], ['ev2'], ['ev3']]),
+    ).start()
+
+    with structlog.testing.capture_logs() as logs:
+        await stage.execute(input=input_q)
+
+    warnings = [entry for entry in logs if entry['log_level'] == 'warning']
+    assert len(warnings) == 1
+    assert stage._timed_out_writes['Writing with <mock output>'] == 3  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_write_timeouts_are_throttled_per_plugin():
+    """A saturated plugin does not mute timeouts of another one."""
+    p1 = _make_mock_output_plugin()
+    p1.write.side_effect = _slow_write
+    p1.__str__ = MagicMock(return_value='<mock output 1>')  # type: ignore[method-assign]
+
+    p2 = _make_mock_output_plugin()
+    p2.write.side_effect = _slow_write
+    p2.__str__ = MagicMock(return_value='<mock output 2>')  # type: ignore[method-assign]
+
+    params = _make_params(write_timeout=1)
+    stage = _make_output_stage(plugins=[p1, p2], params=params)
+    input_q: PipelineQueue[list[str]] = PipelineQueue(maxsize=10)
+
+    threading.Thread(
+        target=_feed_and_close,
+        args=(input_q, [['ev1']]),
+    ).start()
+
+    with structlog.testing.capture_logs() as logs:
+        await stage.execute(input=input_q)
+
+    reported = {
+        entry['task_name'] for entry in logs if entry['log_level'] == 'warning'
+    }
+    assert reported == {
+        'Writing with <mock output 1>',
+        'Writing with <mock output 2>',
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #233.

## The message was not truthful

`Write operation timed out, EPS is to high for output target, consider decreasing EPS or changing batching settings to avoid loosing events`

Four problems, all confirmed against the code:

1. **Typos** — `is to high`, `loosing`.
2. **Invented diagnosis.** The stage knows one fact: a single write exceeded `write_timeout` and was cancelled. A slow or unavailable target, an oversized batch, too many concurrent writes and a low `write_timeout` produce the same symptom as an excessive rate. Concretely for the reported case: the `opensearch` plugin's own `request_timeout` defaults to **300 s** while `write_timeout` defaults to **10 s** and the batch to **10 000** events — the stage cancels the bulk request 30x earlier than the plugin would give up, so the usual fix there is the opposite of the advice given.
3. **Wrong tense.** The events are not at risk, they are already gone: the cancellation lands inside `OutputPlugin.write`, the bare `except:` catches it and the whole batch goes to `_write_failed` / `_format_failed`. There is no retry.
4. **Style.** `LOGGING.md` has a `hint` field for actionable suggestions (already used in `sample_reader.py`); the advice was inlined into the event string instead, against the static-message rule.

## What changed

**Output stage.** The message states the observed fact — `Write operations timed out, their events are counted as failed` — and the remedies moved to `hint`.

**Throttling.** `Throttler(limit=1, period=10)`, matching the queue warnings, but keyed by task name so a saturated target cannot mute the other output plugins. A throttle alone would hide 99 of 100 timeouts, so the warning also carries `count` — the cumulative number of timed-out writes for that plugin over the run. Cumulative rather than since-last-report, because resetting on report drops the tail of suppressed timeouts when a run ends.

**Queue-full warnings.** The push logic itself is correct: checking `is_full` before `put` catches exactly the moment the producer is about to block, and suppressing the warning in sample mode is right — there is no schedule to fall behind there. The wording was reshaped to the same shape as above. Both diagnoses were honest, but both also inlined the advice and named the rate as the only lever. The events-queue hint names its culprit precisely (only the output stage drains it); the timestamps-queue hint names both downstream stages, since the event stage may itself be blocked on a full events queue.

## Tests

Seven new tests: warning content for a write timeout, throttling of repeats for one plugin, independence of throttles across plugins, and a live/sample pair per queue. The queue tests are deterministic — the stage blocks on `put` against a queue that is never drained and is released through `shutdown()`, so nothing races on draining.

`ruff check`, `ruff format --check` clean, `mypy` 0 errors, 1554 tests pass.

## Not in this diff

No docs change: the log text is not documented anywhere and the `write_timeout` description in `startup-yml.mdx` is already accurate.

Possible follow-ups:

- reconcile the `write_timeout` default (10 s) with plugin-level timeouts — it currently cuts `opensearch` off an order of magnitude earlier than the plugin itself would;
- note in `startup-yml.mdx` that the events of a cancelled write are counted as failed (separate PR in the docs repository).