### PR TITLE
perf: form batches by size wherever the batch delay bounds nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### ⚡ Performance
 
-- **Merged due batches while catching up in live mode** — a generator started on a past time range, or one that fell behind real time, drained its backlog in batches capped by `batch.delay`, although timestamps that are already due carry no waiting for that cap to bound. Such batches are now merged up to `batch.size`, so the same backlog passes through the pipeline in far fewer batches — 2 instead of 1798 for half an hour of backlog at 10 events per second. Batching of timestamps that are still ahead of real time is unchanged, as is batch mode
+- **Formed batches by size wherever the delay bounds nothing** — `batch.delay` caps the time span of the timestamps one batch covers, which bounds the lag batching adds to delivery. Timestamps that have already passed carry no such lag, and sample mode emits on no schedule at all, so in both cases the cap only cut the stream into batches the size of the event rate. Both are now grouped by `batch.size` alone: half an hour of live backlog at 10 events per second drains in 2 batches instead of 1798. `batch.delay` still forms the batches of timestamps ahead of real time in live mode, and still applies everywhere `batch.size` is unset, where it is the only limit a batch has. A sample-mode run through a per-batch formatter such as `json-batch` writes larger arrays than before as a result
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### ⚡ Performance
+
+- **Merged due batches while catching up in live mode** — a generator started on a past time range, or one that fell behind real time, drained its backlog in batches capped by `batch.delay`, although timestamps that are already due carry no waiting for that cap to bound. Such batches are now merged up to `batch.size`, so the same backlog passes through the pipeline in far fewer batches — 2 instead of 1798 for half an hour of backlog at 10 events per second. Batching of timestamps that are still ahead of real time is unchanged, as is batch mode
+
 ### 🐛 Bug Fixes
 
 - **Stopped escaping non-ASCII text in configuration files** — a project saved through Studio, the API or MCP had its Cyrillic and other non-ASCII values written out as `\uXXXX` sequences, in `generator.yml` as well as in the instance settings and the startup file. Values are now stored as they were entered, and JSON-format logs and MCP resources report them the same way

--- a/eventum/core/stages/input_stage.py
+++ b/eventum/core/stages/input_stage.py
@@ -172,11 +172,21 @@ class InputStage:
 
             if self._params.live_mode:
                 logger.debug('Wrapping to batch scheduler')
+
+                # interactive plugins publish timestamps as they come,
+                # so their due batches are never merged
+                merge_due_batches = not item['lax_batcher_mode']
+
                 result.append(
                     BatchScheduler(
                         source=batcher,
                         timezone=self._timezone,
                         stop_event=stop_event,
+                        max_batch_size=(
+                            self._params.batch.size
+                            if merge_due_batches
+                            else None
+                        ),
                     ),
                 )
             else:

--- a/eventum/core/stages/input_stage.py
+++ b/eventum/core/stages/input_stage.py
@@ -156,11 +156,21 @@ class InputStage:
                 continue
 
             logger.debug('Wrapping to timestamps batcher')
+
+            # delay bounds the delivery lag batching adds, and only
+            # live mode delivers on a schedule to lag behind; without
+            # size it is the only limit of the batch, so it still holds
+            delay_applies = (
+                self._params.live_mode or self._params.batch.size is None
+            )
+
             try:
                 batcher = TimestampsBatcher(
                     source=merged,
                     batch_size=self._params.batch.size,
-                    batch_delay=self._params.batch.delay,
+                    batch_delay=(
+                        self._params.batch.delay if delay_applies else None
+                    ),
                     lax=item['lax_batcher_mode'],
                 )
             except ValueError as e:

--- a/eventum/core/tests/test_input_stage.py
+++ b/eventum/core/tests/test_input_stage.py
@@ -12,6 +12,7 @@ import structlog.testing
 from eventum.core.parameters import BatchParameters, GeneratorParameters
 from eventum.core.queue import PipelineQueue
 from eventum.core.stages.input_stage import InputStage
+from eventum.plugins.input.batcher import TimestampsBatcher
 from eventum.plugins.input.protocols import IdentifiedTimestamps
 from eventum.plugins.input.scheduler import BatchScheduler
 
@@ -147,6 +148,63 @@ def test_configure_sample_mode_leaves_batcher_unwrapped():
     stage.configure(stop_event=threading.Event())
 
     assert not isinstance(stage._configured_non_interactive, BatchScheduler)
+
+
+def test_configure_sample_mode_drops_delay():
+    """Sample mode delivers on no schedule, so size forms the batch."""
+    p1 = _make_mock_input_plugin(plugin_id=1, is_interactive=False)
+    stage = InputStage(
+        plugins=[p1],
+        params=_make_params(
+            live_mode=False,
+            batch=BatchParameters(size=500, delay=1.0),
+        ),
+    )
+    stage.configure(stop_event=threading.Event())
+
+    batcher = stage._configured_non_interactive
+
+    assert isinstance(batcher, TimestampsBatcher)
+    assert batcher._batch_size == 500
+    assert batcher._batch_delay is None
+
+
+def test_configure_sample_mode_keeps_delay_without_size():
+    """Delay is the only limit of the batch when size is not set."""
+    p1 = _make_mock_input_plugin(plugin_id=1, is_interactive=False)
+    stage = InputStage(
+        plugins=[p1],
+        params=_make_params(
+            live_mode=False,
+            batch=BatchParameters(delay=1.0),
+        ),
+    )
+    stage.configure(stop_event=threading.Event())
+
+    batcher = stage._configured_non_interactive
+
+    assert isinstance(batcher, TimestampsBatcher)
+    assert batcher._batch_size is None
+    assert batcher._batch_delay == 1.0
+
+
+def test_configure_live_mode_keeps_delay():
+    """Live mode delivers on a schedule, so delay bounds the lag."""
+    p1 = _make_mock_input_plugin(plugin_id=1, is_interactive=False)
+    stage = InputStage(
+        plugins=[p1],
+        params=_make_params(
+            live_mode=True,
+            batch=BatchParameters(size=500, delay=1.0),
+        ),
+    )
+    stage.configure(stop_event=threading.Event())
+
+    scheduler = stage._configured_non_interactive
+
+    assert isinstance(scheduler, BatchScheduler)
+    assert isinstance(scheduler._source, TimestampsBatcher)
+    assert scheduler._source._batch_delay == 1.0
 
 
 def test_configure_zero_plugins():

--- a/eventum/core/tests/test_input_stage.py
+++ b/eventum/core/tests/test_input_stage.py
@@ -9,10 +9,11 @@ from unittest.mock import MagicMock
 import numpy as np
 import structlog.testing
 
-from eventum.core.parameters import GeneratorParameters
+from eventum.core.parameters import BatchParameters, GeneratorParameters
 from eventum.core.queue import PipelineQueue
 from eventum.core.stages.input_stage import InputStage
 from eventum.plugins.input.protocols import IdentifiedTimestamps
+from eventum.plugins.input.scheduler import BatchScheduler
 
 
 def _make_timestamps(
@@ -83,7 +84,7 @@ def test_input_tags_map():
 
 
 def test_plugins_property():
-    """plugins property returns the plugin list."""
+    """Plugins property returns the plugin list."""
     p1 = _make_mock_input_plugin()
     stage = InputStage(plugins=[p1], params=_make_params())
     assert stage.plugins == [p1]
@@ -101,6 +102,51 @@ def test_configure_single_non_interactive():
 
     assert stage._configured_non_interactive is not None
     assert stage._configured_interactive is None
+
+
+def test_configure_live_mode_gives_batch_size_to_scheduler():
+    """Scheduler merges due batches up to the configured batch size."""
+    p1 = _make_mock_input_plugin(plugin_id=1, is_interactive=False)
+    stage = InputStage(
+        plugins=[p1],
+        params=_make_params(
+            live_mode=True,
+            batch=BatchParameters(size=500, delay=1.0),
+        ),
+    )
+    stage.configure(stop_event=threading.Event())
+
+    scheduler = stage._configured_non_interactive
+
+    assert isinstance(scheduler, BatchScheduler)
+    assert scheduler._max_batch_size == 500
+
+
+def test_configure_live_mode_keeps_interactive_batches_unmerged():
+    """Interactive plugins publish timestamps as they come."""
+    p1 = _make_mock_input_plugin(plugin_id=1, is_interactive=True)
+    stage = InputStage(
+        plugins=[p1],
+        params=_make_params(
+            live_mode=True,
+            batch=BatchParameters(size=500, delay=1.0),
+        ),
+    )
+    stage.configure(stop_event=threading.Event())
+
+    scheduler = stage._configured_interactive
+
+    assert isinstance(scheduler, BatchScheduler)
+    assert scheduler._max_batch_size is None
+
+
+def test_configure_sample_mode_leaves_batcher_unwrapped():
+    """Without live mode there is no scheduler to merge due batches."""
+    p1 = _make_mock_input_plugin(plugin_id=1, is_interactive=False)
+    stage = InputStage(plugins=[p1], params=_make_params(live_mode=False))
+    stage.configure(stop_event=threading.Event())
+
+    assert not isinstance(stage._configured_non_interactive, BatchScheduler)
 
 
 def test_configure_zero_plugins():

--- a/eventum/plugins/input/accumulator.py
+++ b/eventum/plugins/input/accumulator.py
@@ -1,0 +1,123 @@
+"""Accumulator of timestamp arrays into size limited batches."""
+
+import numpy as np
+
+from eventum.plugins.input.protocols import IdentifiedTimestamps
+from eventum.plugins.input.utils.array_utils import chunk_array
+
+
+class BatchAccumulator:
+    """Accumulator of identified timestamps into batches of limited
+    size. Pushed arrays are accumulated until they form a complete
+    batch, incomplete remainder is kept for the following pushes until
+    it is taken away by flushing. Both operations return batches that
+    are ready to be published.
+
+    Parameters
+    ----------
+    max_size : int | None
+        Maximum size of formed batches, not limited if value is `None`.
+
+    """
+
+    def __init__(self, max_size: int | None) -> None:
+        """Initialize accumulator.
+
+        Parameters
+        ----------
+        max_size : int | None
+            Maximum size of formed batches, not limited if value is
+            `None`.
+
+        Raises
+        ------
+        ValueError
+            If `max_size` is less than 1.
+
+        """
+        if max_size is not None and max_size < 1:
+            msg = 'Parameter `max_size` must be greater or equal to 1'
+            raise ValueError(msg)
+
+        self._max_size = max_size
+        self._arrays: list[IdentifiedTimestamps] = []
+        self._size = 0
+
+    def push(
+        self,
+        array: IdentifiedTimestamps,
+    ) -> list[IdentifiedTimestamps]:
+        """Push array of timestamps to accumulator.
+
+        Parameters
+        ----------
+        array : IdentifiedTimestamps
+            Array to push.
+
+        Returns
+        -------
+        list[IdentifiedTimestamps]
+            Batches completed by this push, empty list if none of them
+            is complete yet.
+
+        """
+        if array.size == 0:
+            return []
+
+        self._arrays.append(array)
+        self._size += array.size
+
+        if self._max_size is None or self._size < self._max_size:
+            return []
+
+        batches = chunk_array(
+            array=np.concatenate(self._arrays),
+            size=self._max_size,
+        )
+        self._reset()
+
+        if batches[-1].size < self._max_size:
+            self._push_back(batches.pop())
+
+        return batches
+
+    def flush(self) -> list[IdentifiedTimestamps]:
+        """Take away all accumulated timestamps as incomplete batch.
+
+        Returns
+        -------
+        list[IdentifiedTimestamps]
+            Batch of accumulated timestamps, empty list if accumulator
+            is empty.
+
+        """
+        if not self._arrays:
+            return []
+
+        array = np.concatenate(self._arrays)
+        self._reset()
+
+        return [array]
+
+    def _push_back(self, array: IdentifiedTimestamps) -> None:
+        """Return array to the emptied accumulator."""
+        self._arrays.append(array)
+        self._size += array.size
+
+    def _reset(self) -> None:
+        """Drop all accumulated timestamps."""
+        self._arrays.clear()
+        self._size = 0
+
+    @property
+    def size(self) -> int:
+        """Current number of accumulated timestamps."""
+        return self._size
+
+    @property
+    def first_timestamp(self) -> np.datetime64 | None:
+        """First accumulated timestamp, `None` if accumulator is empty."""
+        if not self._arrays:
+            return None
+
+        return self._arrays[0]['timestamp'][0]

--- a/eventum/plugins/input/batcher.py
+++ b/eventum/plugins/input/batcher.py
@@ -2,17 +2,18 @@
 
 from collections.abc import Iterator
 from datetime import timedelta
-from typing import cast, override
+from typing import override
 
 import numpy as np
-from numpy.typing import NDArray
 
+from eventum.plugins.input.accumulator import BatchAccumulator
 from eventum.plugins.input.protocols import (
     IdentifiedTimestamps,
     SupportsIdentifiedTimestampsIterate,
     SupportsIdentifiedTimestampsSizedIterate,
 )
-from eventum.plugins.input.utils.array_utils import chunk_array
+
+DEFAULT_READ_SIZE = 10_000
 
 
 class TimestampsBatcher(SupportsIdentifiedTimestampsIterate):
@@ -50,9 +51,9 @@ class TimestampsBatcher(SupportsIdentifiedTimestampsIterate):
             `None`, cannot be  less than `MIN_BATCH_SIZE` attribute.
 
         batch_delay: float | None, default=None
-            Maximum time (in seconds) for single batch to accumulate
-            incoming timestamps, not limited if value is `None`, cannot be
-            less then `MIN_BATCH_DELAY` attribute.
+            Maximum time span (in seconds) of timestamps accumulated
+            into a single batch, not limited if value is `None`, cannot
+            be less then `MIN_BATCH_DELAY` attribute.
 
         lax : bool, default=False
             Whether the batches should not be accumulated but only
@@ -88,61 +89,26 @@ class TimestampsBatcher(SupportsIdentifiedTimestampsIterate):
         self._source = source
         self._lax_mode_enabled = lax
 
-    def _iterate_without_delay(
+    def _get_cutoff_index(
         self,
-        iterator: Iterator[IdentifiedTimestamps],
-    ) -> Iterator[IdentifiedTimestamps]:
-        """Iterate over batches without a set delay parameter.
-
-        Parameters
-        ----------
-        iterator: Iterator[IdentifiedTimestamps]
-            Iterator to use.
-
-        """
-        self._batch_size = cast('int', self._batch_size)
-        current_size = 0
-        to_concatenate: list[IdentifiedTimestamps] = []
-
-        for array in iterator:
-            to_concatenate.append(array)
-            current_size += array.size
-
-            if current_size >= self._batch_size or self._lax_mode_enabled:
-                chunks = chunk_array(
-                    array=np.concatenate(to_concatenate),
-                    size=self._batch_size,
-                )
-                to_concatenate.clear()
-                current_size = 0
-
-                if (
-                    chunks[-1].size < self._batch_size
-                    and not self._lax_mode_enabled
-                ):
-                    last_partial_chunk = chunks.pop()
-                    to_concatenate.append(last_partial_chunk)
-                    current_size += last_partial_chunk.size
-
-                yield from chunks
-
-        if to_concatenate:
-            yield np.concatenate(to_concatenate)
-
-    def _get_cutoff_index_by_delay(
-        self,
-        latest: np.datetime64,
-        array: NDArray[np.datetime64],
+        accumulator: BatchAccumulator,
+        array: IdentifiedTimestamps,
+        window: np.timedelta64 | None,
     ) -> int:
-        """Get cutoff index by delay condition.
+        """Get index the array must be cut at to keep the time span of
+        the accumulated batch within the window.
 
         Parameters
         ----------
-        latest : np.datetime64
-            Latest timestamp for the batch.
+        accumulator : BatchAccumulator
+            Accumulator the array is going to be pushed to.
 
-        array : NDArray[np.datetime64]
+        array : IdentifiedTimestamps
             Array to find index for.
+
+        window : np.timedelta64 | None
+            Maximum time span of a single batch, not limited if value
+            is `None`.
 
         Returns
         -------
@@ -150,115 +116,75 @@ class TimestampsBatcher(SupportsIdentifiedTimestampsIterate):
             Cutoff index.
 
         """
-        if latest < array[-1]:
+        if window is None:
+            return array.size
+
+        first_timestamp = accumulator.first_timestamp
+
+        if first_timestamp is None:
+            first_timestamp = array['timestamp'][0]
+
+        latest_timestamp = first_timestamp + window
+        timestamps = array['timestamp']
+
+        if latest_timestamp < timestamps[-1]:
             return int(
                 np.searchsorted(
-                    a=array,
-                    v=latest,  # type: ignore[assignment]
+                    a=timestamps,
+                    v=latest_timestamp,  # type: ignore[assignment]
                     side='left',
                 ),
             )
 
         return array.size
 
-    def _get_cutoff_index_by_size(
-        self,
-        current_size: int,
-        array: NDArray,
-    ) -> int:
-        """Get cutoff index by size condition.
-
-        Parameters
-        ----------
-        current_size : int
-            Current size of batch.
-
-        array : NDArray
-            Array to find index for.
-
-        Returns
-        -------
-        int
-            Cutoff index.
-
-        """
-        if self._batch_size is None:
-            return array.size
-
-        if (current_size + array.size) >= self._batch_size:
-            return self._batch_size - current_size
-
-        return array.size
-
-    def _iterate_with_delay(
+    def _iterate(
         self,
         iterator: Iterator[IdentifiedTimestamps],
+        window: np.timedelta64 | None,
     ) -> Iterator[IdentifiedTimestamps]:
-        """Iterate over batches with a set delay parameter.
+        """Iterate over batches.
 
         Parameters
         ----------
         iterator: Iterator[IdentifiedTimestamps]
             Iterator to use.
 
+        window : np.timedelta64 | None
+            Maximum time span of a single batch, not limited if value
+            is `None`.
+
+        Yields
+        ------
+        IdentifiedTimestamps
+            Batch of timestamps.
+
         """
-        self._batch_delay = cast('float', self._batch_delay)
+        accumulator = BatchAccumulator(max_size=self._batch_size)
 
-        delta = np.timedelta64(  # type: ignore[call-overload]
-            timedelta(seconds=self._batch_delay),
-            'us',
-        )
-        to_concatenate = []
-        prev_array: IdentifiedTimestamps | None = None
+        for array in iterator:
+            remaining = array
 
-        current_size = 0
-        latest_timestamp: np.datetime64 | None = None
+            while remaining.size > 0:
+                cutoff_index = self._get_cutoff_index(
+                    accumulator=accumulator,
+                    array=remaining,
+                    window=window,
+                )
+                batches = accumulator.push(remaining[:cutoff_index])
+                remaining = remaining[cutoff_index:]
 
-        while True:
-            if prev_array is None:
-                try:
-                    array = next(iterator)
-                except StopIteration:
-                    break
-            else:
-                array = prev_array
-                prev_array = None
+                if batches:
+                    # window is recomputed for the kept remainder
+                    yield from batches
+                elif remaining.size > 0:
+                    # window is closed by the timestamps left out of it
+                    yield from accumulator.flush()
 
-            if latest_timestamp is None:
-                latest_timestamp = array['timestamp'][0] + delta
+                if self._lax_mode_enabled:
+                    yield from accumulator.flush()
 
-            delay_cutoff_index = self._get_cutoff_index_by_delay(
-                latest=latest_timestamp,  # type: ignore[arg-type]
-                array=array['timestamp'],
-            )
-            size_cutoff_index = self._get_cutoff_index_by_size(
-                current_size=current_size,
-                array=array,
-            )
-            cutoff_index = min(delay_cutoff_index, size_cutoff_index)
-
-            # process cutoff index
-            if cutoff_index >= array.size and not self._lax_mode_enabled:
-                to_concatenate.append(array)
-                current_size += array.size
-            else:
-                left_part = array[:cutoff_index]
-                right_part = array[cutoff_index:]
-
-                if left_part.size > 0:
-                    to_concatenate.append(left_part)
-
-                if right_part.size > 0:
-                    prev_array = right_part
-
-                yield np.concatenate(to_concatenate)
-
-                to_concatenate.clear()
-                current_size = 0
-                latest_timestamp = None
-
-        if to_concatenate:
-            yield np.concatenate(to_concatenate)
+        yield from accumulator.flush()
 
     @override
     def iterate(
@@ -267,11 +193,16 @@ class TimestampsBatcher(SupportsIdentifiedTimestampsIterate):
         skip_past: bool = True,
     ) -> Iterator[IdentifiedTimestamps]:
         iterator = self._source.iterate(
-            size=self._batch_size or 10_000,
+            size=self._batch_size or DEFAULT_READ_SIZE,
             skip_past=skip_past,
         )
 
         if self._batch_delay is None:
-            yield from self._iterate_without_delay(iterator=iterator)
+            window = None
         else:
-            yield from self._iterate_with_delay(iterator=iterator)
+            window = np.timedelta64(  # type: ignore[call-overload]
+                timedelta(seconds=self._batch_delay),
+                'us',
+            )
+
+        yield from self._iterate(iterator=iterator, window=window)

--- a/eventum/plugins/input/scheduler.py
+++ b/eventum/plugins/input/scheduler.py
@@ -8,6 +8,7 @@ from threading import Event
 from typing import TYPE_CHECKING, override
 from zoneinfo import ZoneInfo
 
+from eventum.plugins.input.accumulator import BatchAccumulator
 from eventum.plugins.input.protocols import (
     IdentifiedTimestamps,
     SupportsIdentifiedTimestampsIterate,
@@ -26,6 +27,10 @@ class BatchScheduler(SupportsIdentifiedTimestampsIterate):
     of timestamps and does not yield them immediately, but it waits
     until current time reaches the last timestamp in the batch.
 
+    Batches that are already due are published without waiting, so they
+    are merged together until they reach `max_batch_size`, instead of
+    being published one by one.
+
     Parameters
     ----------
     source : SupportsIdentifiedTimestampsIterate
@@ -39,6 +44,10 @@ class BatchScheduler(SupportsIdentifiedTimestampsIterate):
         If provided, the scheduler will check this event during sleep
         and exit early when it is set.
 
+    max_batch_size : int | None, default=None
+        Maximum size of batches merged from the due ones, due batches
+        are published as is if value is `None`.
+
     """
 
     def __init__(
@@ -46,6 +55,7 @@ class BatchScheduler(SupportsIdentifiedTimestampsIterate):
         source: SupportsIdentifiedTimestampsIterate,
         timezone: ZoneInfo,
         stop_event: Event | None = None,
+        max_batch_size: int | None = None,
     ) -> None:
         """Initialize scheduler.
 
@@ -62,10 +72,54 @@ class BatchScheduler(SupportsIdentifiedTimestampsIterate):
             If provided, the scheduler will check this event during
             sleep and exit early when it is set.
 
+        max_batch_size : int | None, default=None
+            Maximum size of batches merged from the due ones, due
+            batches are published as is if value is `None`.
+
         """
         self._source = source
         self._timezone = timezone
         self._stop_event = stop_event
+        self._max_batch_size = max_batch_size
+
+    def _get_delay(self, array: IdentifiedTimestamps) -> float:
+        """Get time to wait before publishing the batch.
+
+        Parameters
+        ----------
+        array : IdentifiedTimestamps
+            Batch of timestamps.
+
+        Returns
+        -------
+        float
+            Number of seconds to wait, zero for the due batch.
+
+        """
+        latest_timestamp: np.datetime64 = array['timestamp'][-1]
+        delta = latest_timestamp - now64(self._timezone)
+
+        return max(timedelta64_to_seconds(timedelta=delta), 0)
+
+    def _wait(self, delay: float) -> bool:
+        """Wait for the specified time.
+
+        Parameters
+        ----------
+        delay : float
+            Number of seconds to wait.
+
+        Returns
+        -------
+        bool
+            Whether the waiting was interrupted by stop event.
+
+        """
+        if self._stop_event is None:
+            time.sleep(delay)
+            return False
+
+        return self._stop_event.wait(timeout=delay)
 
     @override
     def iterate(
@@ -73,17 +127,21 @@ class BatchScheduler(SupportsIdentifiedTimestampsIterate):
         *,
         skip_past: bool = True,
     ) -> Iterator[IdentifiedTimestamps]:
-        for array in self._source.iterate(skip_past=skip_past):
-            now = now64(self._timezone)
-            latest_ts: np.datetime64 = array['timestamp'][-1]
-            delta = latest_ts - now
-            delay = max(timedelta64_to_seconds(timedelta=delta), 0)
+        accumulator = BatchAccumulator(max_size=self._max_batch_size)
 
-            if delay > 0:
-                if self._stop_event is not None:
-                    if self._stop_event.wait(timeout=delay):
-                        return
-                else:
-                    time.sleep(delay)
+        for array in self._source.iterate(skip_past=skip_past):
+            delay = self._get_delay(array)
+
+            if delay == 0 and self._max_batch_size is not None:
+                yield from accumulator.push(array)
+                continue
+
+            # due timestamps are published before waiting for the rest
+            yield from accumulator.flush()
+
+            if delay > 0 and self._wait(delay):
+                return
 
             yield array
+
+        yield from accumulator.flush()

--- a/eventum/plugins/input/tests/test_accumulator.py
+++ b/eventum/plugins/input/tests/test_accumulator.py
@@ -1,0 +1,123 @@
+import numpy as np
+import pytest
+
+from eventum.plugins.input.accumulator import BatchAccumulator
+from eventum.plugins.input.protocols import IdentifiedTimestamps
+
+
+def make_timestamps(count: int, start: int = 0) -> IdentifiedTimestamps:
+    array = np.empty(
+        count,
+        dtype=[('timestamp', 'datetime64[us]'), ('id', 'uint16')],
+    )
+    array['timestamp'] = np.datetime64(
+        '2024-01-01T00:00:00',
+        'us',
+    ) + np.arange(start, start + count).astype('timedelta64[s]')
+    array['id'] = 1
+
+    return array
+
+
+def test_invalid_max_size():
+    with pytest.raises(ValueError):
+        BatchAccumulator(max_size=0)
+
+
+def test_push_incomplete_batch():
+    accumulator = BatchAccumulator(max_size=10)
+
+    assert accumulator.push(make_timestamps(4)) == []
+    assert accumulator.push(make_timestamps(5)) == []
+    assert accumulator.size == 9
+
+
+def test_push_complete_batch():
+    accumulator = BatchAccumulator(max_size=10)
+
+    accumulator.push(make_timestamps(4))
+    batches = accumulator.push(make_timestamps(6))
+
+    assert len(batches) == 1
+    assert batches[0].size == 10
+    assert accumulator.size == 0
+
+
+def test_push_exceeding_batches():
+    accumulator = BatchAccumulator(max_size=10)
+
+    batches = accumulator.push(make_timestamps(25))
+
+    assert [batch.size for batch in batches] == [10, 10]
+    assert accumulator.size == 5
+
+
+def test_push_empty_array():
+    accumulator = BatchAccumulator(max_size=10)
+
+    assert accumulator.push(make_timestamps(0)) == []
+    assert accumulator.size == 0
+
+
+def test_push_unlimited_size():
+    accumulator = BatchAccumulator(max_size=None)
+
+    assert accumulator.push(make_timestamps(1000)) == []
+    assert accumulator.size == 1000
+
+    flushed = accumulator.flush()
+
+    assert [batch.size for batch in flushed] == [1000]
+
+
+def test_flush_empty():
+    accumulator = BatchAccumulator(max_size=10)
+
+    assert accumulator.flush() == []
+
+
+def test_flush_remainder():
+    accumulator = BatchAccumulator(max_size=10)
+
+    accumulator.push(make_timestamps(13))
+    flushed = accumulator.flush()
+
+    assert [batch.size for batch in flushed] == [3]
+    assert accumulator.size == 0
+    assert accumulator.flush() == []
+
+
+def test_timestamps_order_is_preserved():
+    accumulator = BatchAccumulator(max_size=5)
+
+    batches = accumulator.push(make_timestamps(count=12))
+    batches.extend(accumulator.flush())
+
+    assert np.array_equal(
+        np.concatenate(batches),
+        make_timestamps(count=12),
+    )
+
+
+def test_first_timestamp():
+    accumulator = BatchAccumulator(max_size=10)
+
+    assert accumulator.first_timestamp is None
+
+    accumulator.push(make_timestamps(count=4, start=100))
+
+    assert (
+        accumulator.first_timestamp
+        == make_timestamps(1, start=100)[0]['timestamp']
+    )
+
+
+def test_first_timestamp_of_remainder():
+    accumulator = BatchAccumulator(max_size=10)
+
+    accumulator.push(make_timestamps(count=12))
+
+    assert (
+        accumulator.first_timestamp
+        == make_timestamps(count=12)[10]['timestamp']
+    )

--- a/eventum/plugins/input/tests/test_batcher.py
+++ b/eventum/plugins/input/tests/test_batcher.py
@@ -1,5 +1,7 @@
-import pytest
 from zoneinfo import ZoneInfo
+
+import numpy as np
+import pytest
 
 from eventum.plugins.input.adapters import IdentifiedTimestampsPluginAdapter
 from eventum.plugins.input.batcher import TimestampsBatcher
@@ -102,3 +104,103 @@ def test_delay_with_size_batching(uneven_delay_source):
     batches = list(batcher.iterate(skip_past=False))
 
     assert [batch.size for batch in batches] == [10, 10, 10, 15, 5]
+
+
+def make_timestamps(count, step_ms=1000, start_ms=0):
+    array = np.empty(
+        count,
+        dtype=[('timestamp', 'datetime64[us]'), ('id', 'uint16')],
+    )
+    array['timestamp'] = np.datetime64(
+        '2024-01-01T00:00:00', 'us'
+    ) + np.arange(start_ms, start_ms + count * step_ms, step_ms).astype(
+        'timedelta64[ms]'
+    )
+    array['id'] = 1
+
+    return array
+
+
+class FakeSource:
+    """Source yielding predefined arrays regardless of requested size."""
+
+    def __init__(self, arrays):
+        self.arrays = arrays
+
+    def iterate(self, size, *, skip_past=True):
+        yield from self.arrays
+
+
+def test_lax_mode_does_not_accumulate_between_reads():
+    source = FakeSource([make_timestamps(3), make_timestamps(4)])
+    batcher = TimestampsBatcher(
+        source=source, batch_size=10, batch_delay=None, lax=True
+    )
+
+    batches = list(batcher.iterate(skip_past=False))
+
+    assert [batch.size for batch in batches] == [3, 4]
+
+
+def test_lax_mode_chunks_read_by_size():
+    source = FakeSource([make_timestamps(5)])
+    batcher = TimestampsBatcher(
+        source=source, batch_size=2, batch_delay=None, lax=True
+    )
+
+    batches = list(batcher.iterate(skip_past=False))
+
+    assert [batch.size for batch in batches] == [2, 2, 1]
+
+
+def test_delay_window_is_recounted_from_kept_remainder():
+    # 25 timestamps within 1.25 seconds, window covers first 20 of them
+    source = FakeSource([make_timestamps(25, step_ms=50)])
+    batcher = TimestampsBatcher(source=source, batch_size=10, batch_delay=1.0)
+
+    batches = list(batcher.iterate(skip_past=False))
+
+    assert [batch.size for batch in batches] == [10, 10, 5]
+
+
+def test_delay_window_closes_batch_under_size():
+    # 25 timestamps within 2.5 seconds, size is never reached
+    source = FakeSource([make_timestamps(25, step_ms=100)])
+    batcher = TimestampsBatcher(source=source, batch_size=100, batch_delay=1.0)
+
+    batches = list(batcher.iterate(skip_past=False))
+
+    assert [batch.size for batch in batches] == [10, 10, 5]
+
+
+def test_delay_window_spans_several_reads():
+    source = FakeSource(
+        [
+            make_timestamps(3, step_ms=100, start_ms=0),
+            make_timestamps(3, step_ms=100, start_ms=300),
+            make_timestamps(3, step_ms=100, start_ms=1000),
+        ]
+    )
+    batcher = TimestampsBatcher(source=source, batch_size=100, batch_delay=1.0)
+
+    batches = list(batcher.iterate(skip_past=False))
+
+    assert [batch.size for batch in batches] == [6, 3]
+
+
+def test_no_timestamps_are_lost():
+    arrays = [
+        make_timestamps(7, step_ms=100, start_ms=0),
+        make_timestamps(9, step_ms=100, start_ms=700),
+        make_timestamps(4, step_ms=100, start_ms=1600),
+    ]
+    batcher = TimestampsBatcher(
+        source=FakeSource(arrays), batch_size=6, batch_delay=0.5
+    )
+
+    batches = list(batcher.iterate(skip_past=False))
+
+    assert np.array_equal(
+        np.concatenate(batches),
+        np.concatenate(arrays),
+    )

--- a/eventum/plugins/input/tests/test_scheduler.py
+++ b/eventum/plugins/input/tests/test_scheduler.py
@@ -1,8 +1,9 @@
 import time
 from threading import Event, Thread
-
-import pytest
 from zoneinfo import ZoneInfo
+
+import numpy as np
+import pytest
 
 from eventum.plugins.input.adapters import IdentifiedTimestampsPluginAdapter
 from eventum.plugins.input.batcher import TimestampsBatcher
@@ -11,6 +12,33 @@ from eventum.plugins.input.plugins.static.plugin import StaticInputPlugin
 from eventum.plugins.input.plugins.timer.config import TimerInputPluginConfig
 from eventum.plugins.input.plugins.timer.plugin import TimerInputPlugin
 from eventum.plugins.input.scheduler import BatchScheduler
+from eventum.plugins.input.utils.time_utils import now64
+
+
+def make_batch(count, offset_ms):
+    """Make batch of timestamps shifted from the current moment."""
+    array = np.empty(
+        count,
+        dtype=[('timestamp', 'datetime64[us]'), ('id', 'uint16')],
+    )
+    array['timestamp'] = (
+        now64(ZoneInfo('UTC'))
+        + np.timedelta64(offset_ms, 'ms')
+        + np.arange(count).astype('timedelta64[us]')
+    )
+    array['id'] = 1
+
+    return array
+
+
+class FakeSource:
+    """Source yielding predefined batches."""
+
+    def __init__(self, batches):
+        self.batches = batches
+
+    def iterate(self, *, skip_past=True):
+        yield from self.batches
 
 
 @pytest.fixture
@@ -95,3 +123,74 @@ def test_scheduler_stop_event(delayed_source):
 
     assert not t.is_alive(), 'Scheduler thread should have stopped'
     assert (t2 - t1) < 0.5, 'Scheduler should exit early on stop'
+
+
+def test_scheduler_merges_due_batches():
+    source = FakeSource([make_batch(10, offset_ms=-1000) for _ in range(25)])
+    scheduler = BatchScheduler(
+        source=source,
+        timezone=ZoneInfo('UTC'),
+        max_batch_size=100,
+    )
+
+    batches = list(scheduler.iterate(skip_past=False))
+
+    assert [batch.size for batch in batches] == [100, 100, 50]
+
+
+def test_scheduler_publishes_due_batches_as_is_without_max_size():
+    source = FakeSource([make_batch(10, offset_ms=-1000) for _ in range(3)])
+    scheduler = BatchScheduler(
+        source=source,
+        timezone=ZoneInfo('UTC'),
+    )
+
+    batches = list(scheduler.iterate(skip_past=False))
+
+    assert [batch.size for batch in batches] == [10, 10, 10]
+
+
+def test_scheduler_publishes_merged_batch_before_waiting():
+    source = FakeSource(
+        [
+            make_batch(10, offset_ms=-1000),
+            make_batch(10, offset_ms=-500),
+            make_batch(5, offset_ms=500),
+        ]
+    )
+    scheduler = BatchScheduler(
+        source=source,
+        timezone=ZoneInfo('UTC'),
+        max_batch_size=100,
+    )
+
+    t1 = time.time()
+    iterator = scheduler.iterate(skip_past=False)
+    first_batch = next(iterator)
+    t2 = time.time()
+    rest = list(iterator)
+    t3 = time.time()
+
+    assert first_batch.size == 20
+    assert (t2 - t1) < 0.4, 'Due timestamps should not wait for future ones'
+    assert [batch.size for batch in rest] == [5]
+    assert (t3 - t1) >= 0.4
+
+
+def test_scheduler_does_not_merge_batches_across_waiting():
+    source = FakeSource(
+        [
+            make_batch(10, offset_ms=-1000),
+            make_batch(10, offset_ms=300),
+            make_batch(10, offset_ms=-1000),
+        ]
+    )
+    scheduler = BatchScheduler(
+        source=source,
+        timezone=ZoneInfo('UTC'),
+        max_batch_size=100,
+    )
+
+    batches = list(scheduler.iterate(skip_past=False))
+
+    assert [batch.size for batch in batches] == [10, 10, 10]

--- a/eventum/ui/src/pages/InstancePage/tabs/SettingsTab.tsx
+++ b/eventum/ui/src/pages/InstancePage/tabs/SettingsTab.tsx
@@ -202,6 +202,7 @@ export const SettingsTab: FC<SettingsTabProps> = ({ form }) => {
       <Section label="Generation">
         <GenerationParametersSection
           form={form as unknown as UseFormReturnType<GenerationParameters>}
+          liveMode={liveMode}
         />
       </Section>
     </Stack>

--- a/eventum/ui/src/pages/SettingsPage/GenerationParametersSection/index.tsx
+++ b/eventum/ui/src/pages/SettingsPage/GenerationParametersSection/index.tsx
@@ -22,11 +22,17 @@ import { LabelWithTooltip } from '@/components/ui/LabelWithTooltip';
 
 interface GenerationParametersSectionProps {
   form: UseFormReturnType<GenerationParameters>;
+  /**
+   * Emission mode these parameters belong to, when it is known - the
+   * batching note names what forms a batch in that mode. Left out where
+   * the parameters are application-wide defaults serving both modes.
+   */
+  liveMode?: boolean;
 }
 
 export const GenerationParametersSection: FC<
   GenerationParametersSectionProps
-> = ({ form }) => {
+> = ({ form, liveMode }) => {
   const formValues = form.getValues();
   const [batchingMode, setBatchingMode] = useState<
     'size' | 'delay' | 'combined'
@@ -40,6 +46,36 @@ export const GenerationParametersSection: FC<
 
   const [batchSize, setBatchSize] = useState(formValues?.batch?.size);
   const [queueParams, setQueueParams] = useState(formValues.queue);
+
+  /**
+   * What actually forms a batch under the current mode. Delay bounds
+   * the lag batching adds to delivery, so it only forms batches out of
+   * timestamps that are still waited for - unless no size is set, when
+   * it is the only limit a batch has.
+   */
+  const getBatchingNote = (): string | null => {
+    if (batchingMode === 'size') {
+      return null;
+    }
+
+    if (batchingMode === 'delay') {
+      return liveMode === false
+        ? 'No size is set, so batches are formed by time span even in sample mode.'
+        : null;
+    }
+
+    if (liveMode === true) {
+      return 'Timestamps that have already passed are formed into batches by size alone.';
+    }
+
+    if (liveMode === false) {
+      return 'Sample mode emits on no schedule, so batches are formed by size alone.';
+    }
+
+    return 'Delay forms batches only out of timestamps still ahead of real time in live mode. Past timestamps, and every timestamp in sample mode, are batched by size alone.';
+  };
+
+  const batchingNote = getBatchingNote();
 
   form.watch('batch.size', ({ value }) => {
     setBatchSize(value);
@@ -205,6 +241,11 @@ export const GenerationParametersSection: FC<
               key={form.key('batch.delay')}
             />
           </Group>
+          {batchingNote && (
+            <Text size="xs" c="dimmed">
+              {batchingNote}
+            </Text>
+          )}
           <Alert
             variant="default"
             icon={<AlertIcon variant="info" />}

--- a/eventum/ui/src/pages/SettingsPage/GenerationParametersSection/index.tsx
+++ b/eventum/ui/src/pages/SettingsPage/GenerationParametersSection/index.tsx
@@ -193,7 +193,7 @@ export const GenerationParametersSection: FC<
               label={
                 <LabelWithTooltip
                   label="Batch delay"
-                  tooltip="Maximum time for single batch to accumulate incoming timestamps"
+                  tooltip="Maximum time span of timestamps for single batch. In live mode timestamps that are already due are batched by size instead"
                 />
               }
               placeholder="seconds"


### PR DESCRIPTION
Closes #181

## Problem

`batch.delay` caps the time span of timestamp **values** one batch covers, not wall-clock time. What that cap actually buys is a bound on the lag batching adds to delivery: a batch is delivered when its last timestamp comes due, so its first event waits at most `delay` past its own moment.

That bound is meaningless in two places, where the cap only cut the stream into batches the size of the event rate, each paying a full pipeline pass:

- **a live backlog** — a generator started on a past range with `skip_past` disabled, or one that fell behind real time. Those timestamps are due already, the scheduler publishes them without waiting a moment.
- **sample mode** — nothing is delivered on a schedule at all.

## Behaviour

`size` is the primary limit; `delay` applies only where something is waited for, and always when it is the only limit a batch has.

| Configuration | Live, timestamps still ahead | Live, timestamps already passed | Sample |
|---|---|---|---|
| `size` only | `size` | `size` | `size` |
| `size` + `delay` | lesser of `size` and the delay window | **`size`** | **`size`** |
| `delay` only | delay window | delay window | delay window |

Two cells change, and the default configuration (`size: 10000` + `delay: 1.0`) lands in both. The `delay`-only row is deliberately untouched: there `delay` is the only thing bounding the size of a batch, and lifting it would collect a whole backlog — or a whole sample run — into one batch in memory.

## Where each half lives

- **Live backlog** — the scheduler holds the only clock, so it decides. A batch whose last timestamp is already due is accumulated rather than published on its own, and accumulated batches are published as they reach `batch.size`. The first batch that requires waiting publishes what was accumulated before sleeping, so due timestamps never wait for future ones.
- **Sample mode** — the batcher is built without a delay at all, so batches are formed by size. Nothing wraps a clock around it, so the run stays deterministic.

Interactive input plugins are excluded from merging: their timestamps are due by nature, and holding them until a batch fills would defer the events their requests produce.

## Studio

The generation parameters section takes the emission mode where it is known — on the instance page, right next to the mode selector — and names what forms a batch: past timestamps, or every timestamp in sample mode, are grouped by size. In the application-wide settings, which serve both modes, the note states both cases. Nothing is disabled or forbidden; every combination remains configurable.

## Refactor commit

The first commit is behaviour-preserving cleanup the fix builds on: the batcher carried two nearly identical hand-rolled accumulators and reassigned its own fields through `cast` to satisfy the type checker. Both paths now share one `BatchAccumulator`, and the two iteration methods collapse into one parameterized by the time window.

The new batcher tests (lax mode, window recount, window closing, timestamp preservation) were run against the pre-refactor implementation as well — all pass there, so the cleanup changed nothing.

## Measured

Half an hour of live backlog at 10 events per second, `size: 10000`, `delay: 1.0`:

```
 before:   1798 batches, 18000 timestamps, avg batch 10.0
  after:      2 batches, 18000 timestamps, avg batch 9000.0
```

That is the batch count, not end-to-end throughput — the gain is that each batch costs a full pass of event rendering and output writes.

## Compatibility

A sample-mode run through a per-batch formatter (`json-batch`) writes larger arrays than before: previously one array per delay window, now one per `size`. Event content and order are unchanged. Noted in the changelog.

## Verification

`ruff check`, `ruff format --check`, `mypy`, 1591 tests, `eslint`, 88 UI tests, `pnpm build` — all green.

Documentation ships in eventum-generator/docs#63.